### PR TITLE
chore: create sync-repo-settings

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -9,3 +9,4 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'tests'
     - 'cla/google'
+    - 'ci/circleci: build-and-test'

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,11 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings
+# Rules for main branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `main`
+- pattern: main
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
+  requiredStatusCheckContexts:
+    - 'tests'
+    - 'cla/google'


### PR DESCRIPTION
This repo does not use Kokoro for presubmits, so it needs a set of requiredStatusCheckContexts different from [the default](https://github.com/googleapis/repo-automation-bots/blob/21bd620e5e09f3bc6e98995bcd1bce6c9c9ee51a/packages/sync-repo-settings/src/required-checks.json#L45-L48) for Python.

