### PR TITLE
fix: calculate limit value correctly for offset only queries

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -259,7 +259,8 @@ class SpannerSQLCompiler(SQLCompiler):
             text += "\n LIMIT " + self.process(select._limit_clause, **kw)
         if select._offset_clause is not None:
             if select._limit_clause is None:
-                text += "\n LIMIT 9223372036854775805"
+                offset = int(self.process(select._offset_clause, **kw))
+                text += f"\n LIMIT {9223372036854775807-offset}"
             text += " OFFSET " + self.process(select._offset_clause, **kw)
         return text
 

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -259,8 +259,7 @@ class SpannerSQLCompiler(SQLCompiler):
             text += "\n LIMIT " + self.process(select._limit_clause, **kw)
         if select._offset_clause is not None:
             if select._limit_clause is None:
-                offset = int(self.process(select._offset_clause, **kw))
-                text += f"\n LIMIT {9223372036854775807-offset}"
+                text += f"\n LIMIT {9223372036854775807-select._offset}"
             text += " OFFSET " + self.process(select._offset_clause, **kw)
         return text
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1616,6 +1616,31 @@ class ExecutionOptionsTest(fixtures.TestBase):
             assert connection.connection.staleness is None
 
 
+class LimitOffsetTest(fixtures.TestBase):
+    """
+    Check that SQL with an offset and no limit is being generated correctly.
+    """
+
+    def setUp(self):
+        self._engine = create_engine(get_db_url(), pool_size=1)
+        self._metadata = MetaData(bind=self._engine)
+
+        self._table = Table(
+            "users",
+            self._metadata,
+            Column("user_id", Integer, primary_key=True),
+            Column("user_name", String(16), nullable=False),
+        )
+
+        self._metadata.create_all(self._engine)
+
+    def test_offset_only(self):
+        for offset in [1, 7, 10, 100, 1000, 10000]:
+
+            with self._engine.connect().execution_options(read_only=True) as connection:
+                list(connection.execute(self._table.select().offset(offset)).fetchall())
+
+
 class ComputedReflectionFixtureTest(_ComputedReflectionFixtureTest):
     @classmethod
     def define_tables(cls, metadata):


### PR DESCRIPTION
Cloud Spanner does not support OFFSET without LIMIT so LIMIT is added. This LIMIT should be as large as possible.

The maximum value for LIMIT and OFFSET is their combined value (Limit+Offset). The combined value must be less than or equal to INT64MAX.