### PR TITLE
fix: bump up google-cloud-spanner required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ name = "sqlalchemy-spanner"
 description = "SQLAlchemy dialect integrated into Cloud Spanner database"
 dependencies = [
     "sqlalchemy>=1.1.13, <=1.3.23",
-    "google-cloud-spanner>=3.3.0",
+    "google-cloud-spanner>=3.12.0",
     "alembic",
 ]
 extras = {


### PR DESCRIPTION
The [3.12.0](https://github.com/googleapis/python-spanner/releases/tag/v3.12.0) version of the `google-cloud-spanner` is required, as it includes the last JSON relates changes.

Closes #168 