### PR TITLE
fix: connection reset fails when an additional dialect is used

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -48,7 +48,8 @@ from google.cloud.sqlalchemy_spanner._opentelemetry_tracing import trace_call
 @listens_for(Pool, "reset")
 def reset_connection(dbapi_conn, connection_record):
     """An event of returning a connection back to a pool."""
-    dbapi_conn.connection.staleness = None
+    if getattr(dbapi_conn.connection, "staleness") is not None:
+        dbapi_conn.connection.staleness = None
 
 
 # register a method to get a single value of a JSON object

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1578,7 +1578,7 @@ class UserAgentTest(SpannerSpecificTestBase):
             )
 
 
-class ExecutionOptionsReadOnlyTest(fixtures.TestBase):
+class ExecutionOptionsTest(fixtures.TestBase):
     """
     Check that `execution_options()` method correctly
     sets parameters on the underlying DB API connection.
@@ -1601,26 +1601,6 @@ class ExecutionOptionsReadOnlyTest(fixtures.TestBase):
         with self._engine.connect().execution_options(read_only=True) as connection:
             connection.execute(select(["*"], from_obj=self._table)).fetchall()
             assert connection.connection.read_only is True
-
-
-class ExecutionOptionsStalenessTest(fixtures.TestBase):
-    """
-    Check that `execution_options()` method correctly
-    sets parameters on the underlying DB API connection.
-    """
-
-    def setUp(self):
-        self._engine = create_engine(get_db_url(), pool_size=1)
-        self._metadata = MetaData(bind=self._engine)
-
-        self._table = Table(
-            "execution_options2",
-            self._metadata,
-            Column("opt_id", Integer, primary_key=True),
-            Column("opt_name", String(16), nullable=False),
-        )
-
-        self._metadata.create_all(self._engine)
 
     def test_staleness(self):
         with self._engine.connect().execution_options(

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -21,7 +21,6 @@ import os
 import pkg_resources
 import pytest
 import random
-import unittest
 from unittest import mock
 
 import sqlalchemy
@@ -1579,25 +1578,24 @@ class UserAgentTest(SpannerSpecificTestBase):
             )
 
 
-class ExecutionOptionsTest(fixtures.TestBase, unittest.TestCase):
+class ExecutionOptionsTest(fixtures.TestBase):
     """
     Check that `execution_options()` method correctly
     sets parameters on the underlying DB API connection.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls._engine = create_engine(get_db_url(), pool_size=1)
-        cls._metadata = MetaData(bind=cls._engine)
+    def setUp(self):
+        self._engine = create_engine(get_db_url(), pool_size=1)
+        self._metadata = MetaData(bind=self._engine)
 
-        cls._table = Table(
+        self._table = Table(
             "execution_options",
-            cls._metadata,
+            self._metadata,
             Column("opt_id", Integer, primary_key=True),
             Column("opt_name", String(16), nullable=False),
         )
 
-        cls._metadata.create_all(cls._engine)
+        self._metadata.create_all(self._engine)
 
     def test_read_only(self):
         with self._engine.connect().execution_options(read_only=True) as connection:
@@ -1614,10 +1612,7 @@ class ExecutionOptionsTest(fixtures.TestBase, unittest.TestCase):
             }
 
         with self._engine.connect() as connection:
-            assert connection.connection.staleness is None
-
-        with self._engine.connect() as connection:
-            del connection.staleness
+            assert connection.connection.staleness == {}
 
 
 class LimitOffsetTest(fixtures.TestBase):

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1614,7 +1614,7 @@ class ExecutionOptionsStalenessTest(fixtures.TestBase):
         self._metadata = MetaData(bind=self._engine)
 
         self._table = Table(
-            "execution_options",
+            "execution_options2",
             self._metadata,
             Column("opt_id", Integer, primary_key=True),
             Column("opt_name", String(16), nullable=False),

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1584,7 +1584,20 @@ class ExecutionOptionsTest(fixtures.TestBase):
     sets parameters on the underlying DB API connection.
     """
 
-    def setUp(self):
+    # def setUp(self):
+    #     self._engine = create_engine(get_db_url(), pool_size=1)
+    #     self._metadata = MetaData(bind=self._engine)
+
+    #     self._table = Table(
+    #         "execution_options",
+    #         self._metadata,
+    #         Column("opt_id", Integer, primary_key=True),
+    #         Column("opt_name", String(16), nullable=False),
+    #     )
+
+    #     self._metadata.create_all(self._engine)
+
+    def test_read_only(self):
         self._engine = create_engine(get_db_url(), pool_size=1)
         self._metadata = MetaData(bind=self._engine)
 
@@ -1597,12 +1610,23 @@ class ExecutionOptionsTest(fixtures.TestBase):
 
         self._metadata.create_all(self._engine)
 
-    def test_read_only(self):
         with self._engine.connect().execution_options(read_only=True) as connection:
             connection.execute(select(["*"], from_obj=self._table)).fetchall()
             assert connection.connection.read_only is True
 
     def test_staleness(self):
+        self._engine = create_engine(get_db_url(), pool_size=1)
+        self._metadata = MetaData(bind=self._engine)
+
+        self._table = Table(
+            "execution_options2",
+            self._metadata,
+            Column("opt_id", Integer, primary_key=True),
+            Column("opt_name", String(16), nullable=False),
+        )
+
+        self._metadata.create_all(self._engine)
+
         with self._engine.connect().execution_options(
             read_only=True, staleness={"exact_staleness": datetime.timedelta(seconds=5)}
         ) as connection:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1578,7 +1578,7 @@ class UserAgentTest(SpannerSpecificTestBase):
             )
 
 
-class ExecutionOptionsTest(fixtures.TestBase):
+class ExecutionOptionsReadOnlyTest(fixtures.TestBase):
     """
     Check that `execution_options()` method correctly
     sets parameters on the underlying DB API connection.
@@ -1601,6 +1601,26 @@ class ExecutionOptionsTest(fixtures.TestBase):
         with self._engine.connect().execution_options(read_only=True) as connection:
             connection.execute(select(["*"], from_obj=self._table)).fetchall()
             assert connection.connection.read_only is True
+
+
+class ExecutionOptionsStalenessTest(fixtures.TestBase):
+    """
+    Check that `execution_options()` method correctly
+    sets parameters on the underlying DB API connection.
+    """
+
+    def setUp(self):
+        self._engine = create_engine(get_db_url(), pool_size=1)
+        self._metadata = MetaData(bind=self._engine)
+
+        self._table = Table(
+            "execution_options",
+            self._metadata,
+            Column("opt_id", Integer, primary_key=True),
+            Column("opt_name", String(16), nullable=False),
+        )
+
+        self._metadata.create_all(self._engine)
 
     def test_staleness(self):
         with self._engine.connect().execution_options(

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1584,49 +1584,26 @@ class ExecutionOptionsTest(fixtures.TestBase):
     sets parameters on the underlying DB API connection.
     """
 
-    # def setUp(self):
-    #     self._engine = create_engine(get_db_url(), pool_size=1)
-    #     self._metadata = MetaData(bind=self._engine)
+    @classmethod
+    def setUpClass(cls):
+        cls._engine = create_engine(get_db_url(), pool_size=1)
+        cls._metadata = MetaData(bind=cls._engine)
 
-    #     self._table = Table(
-    #         "execution_options",
-    #         self._metadata,
-    #         Column("opt_id", Integer, primary_key=True),
-    #         Column("opt_name", String(16), nullable=False),
-    #     )
-
-    #     self._metadata.create_all(self._engine)
-
-    def test_read_only(self):
-        self._engine = create_engine(get_db_url(), pool_size=1)
-        self._metadata = MetaData(bind=self._engine)
-
-        self._table = Table(
+        cls._table = Table(
             "execution_options",
-            self._metadata,
+            cls._metadata,
             Column("opt_id", Integer, primary_key=True),
             Column("opt_name", String(16), nullable=False),
         )
 
-        self._metadata.create_all(self._engine)
+        cls._metadata.create_all(cls._engine)
 
+    def test_read_only(self):
         with self._engine.connect().execution_options(read_only=True) as connection:
             connection.execute(select(["*"], from_obj=self._table)).fetchall()
             assert connection.connection.read_only is True
 
     def test_staleness(self):
-        self._engine = create_engine(get_db_url(), pool_size=1)
-        self._metadata = MetaData(bind=self._engine)
-
-        self._table = Table(
-            "execution_options2",
-            self._metadata,
-            Column("opt_id", Integer, primary_key=True),
-            Column("opt_name", String(16), nullable=False),
-        )
-
-        self._metadata.create_all(self._engine)
-
         with self._engine.connect().execution_options(
             read_only=True, staleness={"exact_staleness": datetime.timedelta(seconds=5)}
         ) as connection:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1616,6 +1616,9 @@ class ExecutionOptionsTest(fixtures.TestBase, unittest.TestCase):
         with self._engine.connect() as connection:
             assert connection.connection.staleness is None
 
+        with self._engine.connect() as connection:
+            del connection.staleness
+
 
 class LimitOffsetTest(fixtures.TestBase):
     """

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1578,7 +1578,7 @@ class UserAgentTest(SpannerSpecificTestBase):
             )
 
 
-class ExecutionOptionsTest(fixtures.TestBase):
+class ExecutionOptionsTest(fixtures.TestBase, unittest.TestCase):
     """
     Check that `execution_options()` method correctly
     sets parameters on the underlying DB API connection.


### PR DESCRIPTION
Closes #186 