### PR TITLE
fix: connection reset fails when an additional dialect is used

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -48,7 +48,8 @@ from google.cloud.sqlalchemy_spanner._opentelemetry_tracing import trace_call
 @listens_for(Pool, "reset")
 def reset_connection(dbapi_conn, connection_record):
     """An event of returning a connection back to a pool."""
-    dbapi_conn.connection.staleness = None
+    if getattr(dbapi_conn.connection, "staleness") is not None:
+        dbapi_conn.connection.staleness = None
 
 
 # register a method to get a single value of a JSON object

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -48,7 +48,7 @@ from google.cloud.sqlalchemy_spanner._opentelemetry_tracing import trace_call
 @listens_for(Pool, "reset")
 def reset_connection(dbapi_conn, connection_record):
     """An event of returning a connection back to a pool."""
-    if getattr(dbapi_conn.connection, "staleness") is not None:
+    if getattr(dbapi_conn.connection, "staleness", None) is not None:
         dbapi_conn.connection.staleness = None
 
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1616,6 +1616,9 @@ class ExecutionOptionsTest(fixtures.TestBase, unittest.TestCase):
         with self._engine.connect() as connection:
             assert connection.connection.staleness is None
 
+        with self._engine.connect() as connection:
+            del connection.staleness
+
 
 class LimitOffsetTest(fixtures.TestBase):
     """


### PR DESCRIPTION
Closes #186 