### PR TITLE
build(python): switch back to keystore for publication

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -18,7 +18,7 @@ python3 -m pip install --upgrade twine wheel setuptools
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-token")
+TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-1")
 cd github/python-spanner-sqlalchemy
 python3 setup.py sdist bdist_wheel
 twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -23,8 +23,18 @@ env_vars: {
     value: "github/python-spanner-sqlalchemy/.kokoro/release.sh"
 }
 
+# Fetch PyPI password
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "google-cloud-pypi-token-keystore-1"
+    }
+  }
+}
+
 # Tokens needed to report release status back to GitHub
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-token"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
 }


### PR DESCRIPTION
This PR pulls in changes from https://github.com/googleapis/synthtool/pull/1327 as we have migrated from secret manager to keystore for publishing to PyPI.