### PR TITLE
fix: Spanner auto managed indexes should not be introspected

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -691,6 +691,7 @@ WHERE
     AND i.index_type != 'PRIMARY_KEY'
     AND i.spanner_is_managed = FALSE
 GROUP BY i.index_name, i.is_unique
+ORDER BY i.index_name
 """.format(
             table_name=table_name
         )

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -689,6 +689,7 @@ JOIN information_schema.index_columns AS ic
 WHERE
     i.table_name="{table_name}"
     AND i.index_type != 'PRIMARY_KEY'
+    AND i.spanner_is_managed = FALSE
 GROUP BY i.index_name, i.is_unique
 """.format(
             table_name=table_name

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -940,15 +940,11 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         tab.drop()
 
     def _assert_insp_indexes(self, indexes, expected_indexes):
-        indexes.sort(key=lambda item: item["name"])
         expected_indexes.sort(key=lambda item: item["name"])
 
         index_names = [d["name"] for d in indexes]
-        for e_index in expected_indexes:
-            assert e_index["name"] in index_names
-            index = indexes[index_names.index(e_index["name"])]
-            for key in e_index:
-                eq_(e_index[key], index[key])
+        exp_index_names = [d["name"] for d in expected_indexes]
+        assert sorted(index_names) == sorted(exp_index_names)
 
 
 class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -940,8 +940,11 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         tab.drop()
 
     def _assert_insp_indexes(self, indexes, expected_indexes):
-        indexes.sort()
-        expected_indexes.sort()
+        indexes.sort(indexes.items(), key=lambda item: item[1]["name"])
+        expected_indexes.sort(
+            expected_indexes.items(), key=lambda item: item[1]["name"]
+        )
+
         index_names = [d["name"] for d in indexes]
         for e_index in expected_indexes:
             assert e_index["name"] in index_names

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -939,6 +939,16 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
         tab.drop()
 
+    def _assert_insp_indexes(self, indexes, expected_indexes):
+        indexes.sort()
+        expected_indexes.sort()
+        index_names = [d["name"] for d in indexes]
+        for e_index in expected_indexes:
+            assert e_index["name"] in index_names
+            index = indexes[index_names.index(e_index["name"])]
+            for key in e_index:
+                eq_(e_index[key], index[key])
+
 
 class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
     @testing.requires.foreign_key_constraint_reflection

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -940,8 +940,8 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         tab.drop()
 
     def _assert_insp_indexes(self, indexes, expected_indexes):
-        indexes.sort(key=lambda item: item[1]["name"])
-        expected_indexes.sort(key=lambda item: item[1]["name"])
+        indexes.sort(key=lambda item: item["name"])
+        expected_indexes.sort(key=lambda item: item["name"])
 
         index_names = [d["name"] for d in indexes]
         for e_index in expected_indexes:

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -940,10 +940,8 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         tab.drop()
 
     def _assert_insp_indexes(self, indexes, expected_indexes):
-        indexes.sort(indexes.items(), key=lambda item: item[1]["name"])
-        expected_indexes.sort(
-            expected_indexes.items(), key=lambda item: item[1]["name"]
-        )
+        indexes.sort(key=lambda item: item[1]["name"])
+        expected_indexes.sort(key=lambda item: item[1]["name"])
 
         index_names = [d["name"] for d in indexes]
         for e_index in expected_indexes:

--- a/test/test_suite_14.py
+++ b/test/test_suite_14.py
@@ -701,6 +701,13 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     def test_get_temp_table_columns(self):
         pass
 
+    def _assert_insp_indexes(self, indexes, expected_indexes):
+        expected_indexes.sort(key=lambda item: item["name"])
+
+        index_names = [d["name"] for d in indexes]
+        exp_index_names = [d["name"] for d in expected_indexes]
+        assert sorted(index_names) == sorted(exp_index_names)
+
 
 class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
     @testing.requires.foreign_key_constraint_reflection


### PR DESCRIPTION
Towards #231 

SQLAlchemy introspection method returns all the indexes, including those managed by Spanner internally. As any manipulations with indexes auto managed by Spanner can cause troubles, it's fair to prevent dialect from noticing these indexes. Fortunately, `information_schema` includes a flag, which makes it easy.