### PR TITLE
feat:  feat: SQLAlchemy 2.0 support

### DIFF
--- a/google/cloud/sqlalchemy_spanner/requirements.py
+++ b/google/cloud/sqlalchemy_spanner/requirements.py
@@ -109,3 +109,7 @@ class Requirements(SuiteRequirements):  # pragma: no cover
         """target backend supports Decimal() objects using E notation
         to represent very large values."""
         return exclusions.open()
+
+    @property
+    def views(self):
+        return exclusions.open()

--- a/google/cloud/sqlalchemy_spanner/requirements.py
+++ b/google/cloud/sqlalchemy_spanner/requirements.py
@@ -15,6 +15,11 @@
 from sqlalchemy.testing import exclusions
 from sqlalchemy.testing.requirements import SuiteRequirements
 from sqlalchemy.testing.exclusions import against, only_on
+import sqlalchemy
+
+USING_SQLACLCHEMY_20 = False
+if sqlalchemy.__version__.split(".")[0] == "2":
+    USING_SQLACLCHEMY_20 = True
 
 
 class Requirements(SuiteRequirements):  # pragma: no cover
@@ -112,4 +117,4 @@ class Requirements(SuiteRequirements):  # pragma: no cover
 
     @property
     def views(self):
-        return exclusions.open()
+        return exclusions.open() if USING_SQLACLCHEMY_20 else exclusions.closed()

--- a/google/cloud/sqlalchemy_spanner/requirements.py
+++ b/google/cloud/sqlalchemy_spanner/requirements.py
@@ -117,4 +117,5 @@ class Requirements(SuiteRequirements):  # pragma: no cover
 
     @property
     def views(self):
+        """Target database must support VIEWs."""
         return exclusions.open() if USING_SQLACLCHEMY_20 else exclusions.closed()

--- a/google/cloud/sqlalchemy_spanner/requirements.py
+++ b/google/cloud/sqlalchemy_spanner/requirements.py
@@ -15,11 +15,6 @@
 from sqlalchemy.testing import exclusions
 from sqlalchemy.testing.requirements import SuiteRequirements
 from sqlalchemy.testing.exclusions import against, only_on
-import sqlalchemy
-
-USING_SQLACLCHEMY_20 = False
-if sqlalchemy.__version__.split(".")[0] == "2":
-    USING_SQLACLCHEMY_20 = True
 
 
 class Requirements(SuiteRequirements):  # pragma: no cover
@@ -118,4 +113,4 @@ class Requirements(SuiteRequirements):  # pragma: no cover
     @property
     def views(self):
         """Target database must support VIEWs."""
-        return exclusions.open() if USING_SQLACLCHEMY_20 else exclusions.closed()
+        return exclusions.open()

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -655,7 +655,6 @@ class SpannerDialect(DefaultDialect):
             table_filter_query=table_filter_query,
             schema_filter_query=schema_filter_query,
         )
-
         with connection.connection.database.snapshot() as snap:
             columns = list(snap.execute_sql(sql))
             result_dict = {}

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -584,6 +584,10 @@ class SpannerDialect(DefaultDialect):
         return ""
 
     def _get_table_type_query(self, kind):
+        """
+        Generates WHERE condition for Kind of Object.
+        Spanner supports Table and View.
+        """
         if not USING_SQLACLCHEMY_20:
             return ""
         from sqlalchemy.engine.reflection import ObjectKind
@@ -609,6 +613,10 @@ class SpannerDialect(DefaultDialect):
         return table_type_query
 
     def _get_table_filter_query(self, filter_names, info_schema_table):
+        """
+        Generates WHERE query for tables or views for which
+        information is reflected.
+        """
         table_filter_query = ""
         if filter_names is not None:
             for table_name in filter_names:
@@ -644,6 +652,19 @@ class SpannerDialect(DefaultDialect):
 
     @engine_to_connection
     def get_view_names(self, connection, schema=None, **kw):
+        """
+        Gets a list of view name.
+
+        The method is used by SQLAlchemy introspection systems.
+
+        Args:
+            connection (sqlalchemy.engine.base.Connection):
+                SQLAlchemy connection or engine object.
+            schema (str): Optional. Schema name
+
+        Returns:
+            list: List of view names.
+        """
         sql = """
             SELECT table_name
             FROM information_schema.views
@@ -662,6 +683,20 @@ class SpannerDialect(DefaultDialect):
 
     @engine_to_connection
     def get_view_definition(self, connection, view_name, schema=None, **kw):
+        """
+        Gets definition of a particular view.
+
+        The method is used by SQLAlchemy introspection systems.
+
+        Args:
+            connection (sqlalchemy.engine.base.Connection):
+                SQLAlchemy connection or engine object.
+            view_name (str): Name of the view.
+            schema (str): Optional. Schema name
+
+        Returns:
+            str: Definition of view.
+        """
         sql = """
             SELECT view_definition
             FROM information_schema.views
@@ -682,6 +717,30 @@ class SpannerDialect(DefaultDialect):
     def get_multi_columns(
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
+        """
+        Return information about columns in all objects in the given
+        schema.
+
+        The method is used by SQLAlchemy introspection systems.
+
+        Args:
+            connection (sqlalchemy.engine.base.Connection):
+                SQLAlchemy connection or engine object.
+            schema (str): Optional. Schema name
+            filter_names (Sequence[str): Optional. Optionally return information
+                only for the objects listed here.
+            scope (sqlalchemy.engine.reflection.ObjectScope): Optional. Specifies
+                if columns of default, temporary or any tables
+                should be reflected. Spanner does not support temporary.
+            kind (sqlalchemy.engine.reflection.ObjectKind): Optional. Specifies the
+                type of objects to reflect.
+
+        Returns:
+            dictionary: a dictionary where the keys are two-tuple schema,table-name
+                and the values are list of dictionaries, each representing the
+                definition of a database column.
+                The schema is ``None`` if no schema is provided.
+        """
         table_filter_query = self._get_table_filter_query(filter_names, "col")
         schema_filter_query = "AND col.table_schema = '{schema}'".format(
             schema=schema or ""
@@ -790,6 +849,30 @@ class SpannerDialect(DefaultDialect):
     def get_multi_indexes(
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
+        """
+        Return information about indexes in in all objects
+        in the given schema.
+
+        The method is used by SQLAlchemy introspection systems.
+
+        Args:
+            connection (sqlalchemy.engine.base.Connection):
+                SQLAlchemy connection or engine object.
+            schema (str): Optional. Schema name.
+            filter_names (Sequence[str): Optional. Optionally return information
+                only for the objects listed here.
+            scope (sqlalchemy.engine.reflection.ObjectScope): Optional. Specifies
+                if columns of default, temporary or any tables
+                should be reflected. Spanner does not support temporary.
+            kind (sqlalchemy.engine.reflection.ObjectKind): Optional. Specifies the
+                type of objects to reflect.
+
+        Returns:
+            dictionary: a dictionary where the keys are two-tuple schema,table-name
+                and the values are list of dictionaries, each representing the
+                definition of an index.
+                The schema is ``None`` if no schema is provided.
+        """
         table_filter_query = self._get_table_filter_query(filter_names, "i")
         schema_filter_query = "AND i.table_schema = '{schema}'".format(
             schema=schema or ""
@@ -873,6 +956,30 @@ class SpannerDialect(DefaultDialect):
     def get_multi_pk_constraint(
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
+        """
+        Return information about primary key constraints in
+        all tables in the given schema.
+
+        The method is used by SQLAlchemy introspection systems.
+
+        Args:
+            connection (sqlalchemy.engine.base.Connection):
+                SQLAlchemy connection or engine object.
+            schema (str): Optional. Schema name
+            filter_names (Sequence[str): Optional. Optionally return information
+                only for the objects listed here.
+            scope (sqlalchemy.engine.reflection.ObjectScope): Optional. Specifies
+                if columns of default, temporary or any tables
+                should be reflected. Spanner does not support temporary.
+            kind (sqlalchemy.engine.reflection.ObjectKind): Optional. Specifies the
+                type of objects to reflect.
+
+        Returns:
+            dictionary: a dictionary where the keys are two-tuple schema,table-name
+                and the values are list of dictionaries, each representing the
+                definition of a primary key constraint.
+                The schema is ``None`` if no schema is provided.
+        """
         table_filter_query = self._get_table_filter_query(filter_names, "tc")
         schema_filter_query = "AND tc.table_schema = '{schema}'".format(
             schema=schema or ""
@@ -960,6 +1067,30 @@ class SpannerDialect(DefaultDialect):
     def get_multi_foreign_keys(
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
+        """
+        Return information about foreign_keys in all tables
+        in the given schema.
+
+        The method is used by SQLAlchemy introspection systems.
+
+        Args:
+            connection (sqlalchemy.engine.base.Connection):
+                SQLAlchemy connection or engine object.
+            schema (str): Optional. Schema name
+            filter_names (Sequence[str): Optional. Optionally return information
+                only for the objects listed here.
+            scope (sqlalchemy.engine.reflection.ObjectScope): Optional. Specifies
+                if columns of default, temporary or any tables
+                should be reflected. Spanner does not support temporary.
+            kind (sqlalchemy.engine.reflection.ObjectKind): Optional. Specifies the
+                type of objects to reflect.
+
+        Returns:
+            dictionary: a dictionary where the keys are two-tuple schema,table-name
+                and the values are list of dictionaries, each representing
+                a foreign key definition.
+                The schema is ``None`` if no schema is provided.
+        """
         table_filter_query = self._get_table_filter_query(filter_names, "tc")
         schema_filter_query = "AND tc.table_schema = '{schema}'".format(
             schema=schema or ""

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -692,47 +692,6 @@ ORDER BY
         else:
             return _type_map[str_repr]
 
-    # def _build_multi_index_query(self, schema, filter_names, scope, kind):
-
-
-    # @engine_to_connection
-    # def get_multi_indexes(self, connection, schema, filter_names, scope, kind, **kw):
-    #     sql = """
-    #         SELECT
-    #             i.index_name,
-    #             ARRAY_AGG(ic.column_name),
-    #             i.is_unique,
-    #             ARRAY_AGG(ic.column_ordering)
-    #         FROM information_schema.indexes as i
-    #         JOIN information_schema.index_columns AS ic
-    #             ON ic.index_name = i.index_name AND ic.table_name = i.table_name
-    #         WHERE
-    #             i.table_name="{table_name}"
-    #             AND i.index_type != 'PRIMARY_KEY'
-    #             AND i.spanner_is_managed = FALSE
-    #         GROUP BY i.index_name, i.is_unique
-    #         ORDER BY i.index_name
-    #     """.format(
-    #         table_name=table_name
-    #     )
-
-    #     ind_desc = []
-    #     with connection.connection.database.snapshot() as snap:
-    #         rows = snap.execute_sql(sql)
-
-    #         for row in rows:
-    #             ind_desc.append(
-    #                 {
-    #                     "name": row[0],
-    #                     "column_names": row[1],
-    #                     "unique": row[2],
-    #                     "column_sorting": {
-    #                         col: order for col, order in zip(row[1], row[3])
-    #                     },
-    #                 }
-    #             )
-    #     return ind_desc
-
     @engine_to_connection
     def get_indexes(self, connection, table_name, schema=None, **kw):
         """Get the table indexes.

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -50,6 +50,9 @@ USING_SQLACLCHEMY_20 = False
 if sqlalchemy.__version__.split(".")[0] == "2":
     USING_SQLACLCHEMY_20 = True
 
+if USING_SQLACLCHEMY_20:
+    from sqlalchemy.engine.reflection import ObjectKind
+
 
 @listens_for(Pool, "reset")
 def reset_connection(dbapi_conn, connection_record, reset_state=None):
@@ -590,7 +593,6 @@ class SpannerDialect(DefaultDialect):
         """
         if not USING_SQLACLCHEMY_20:
             return ""
-        from sqlalchemy.engine.reflection import ObjectKind
 
         kind = ObjectKind.TABLE if kind is None else kind
         if kind == ObjectKind.MATERIALIZED_VIEW:
@@ -708,7 +710,7 @@ class SpannerDialect(DefaultDialect):
         with connection.connection.database.snapshot() as snap:
             rows = list(snap.execute_sql(sql))
             if rows == []:
-                raise NoSuchTableError(f"{schema}.{view_name}")
+                raise NoSuchTableError(f"{schema if schema else ''}.{view_name}")
             result = rows[0][0]
 
         return result
@@ -807,11 +809,7 @@ class SpannerDialect(DefaultDialect):
         Returns:
             list: The table every column dict-like description.
         """
-        kind = None
-        if USING_SQLACLCHEMY_20:
-            from sqlalchemy.engine.reflection import ObjectKind
-
-            kind = ObjectKind.ANY
+        kind = None if not USING_SQLACLCHEMY_20 else ObjectKind.ANY
         dict = self.get_multi_columns(
             connection, schema=schema, filter_names=[table_name], kind=kind
         )
@@ -941,11 +939,7 @@ class SpannerDialect(DefaultDialect):
         Returns:
             list: List with indexes description.
         """
-        kind = None
-        if USING_SQLACLCHEMY_20:
-            from sqlalchemy.engine.reflection import ObjectKind
-
-            kind = ObjectKind.ANY
+        kind = None if not USING_SQLACLCHEMY_20 else ObjectKind.ANY
         dict = self.get_multi_indexes(
             connection, schema=schema, filter_names=[table_name], kind=kind
         )
@@ -1030,11 +1024,7 @@ class SpannerDialect(DefaultDialect):
         Returns:
             dict: Dict with the primary key constraint description.
         """
-        kind = None
-        if USING_SQLACLCHEMY_20:
-            from sqlalchemy.engine.reflection import ObjectKind
-
-            kind = ObjectKind.ANY
+        kind = None if not USING_SQLACLCHEMY_20 else ObjectKind.ANY
         dict = self.get_multi_pk_constraint(
             connection, schema=schema, filter_names=[table_name], kind=kind
         )
@@ -1184,11 +1174,7 @@ class SpannerDialect(DefaultDialect):
         Returns:
             list: Dicts, each of which describes a foreign key constraint.
         """
-        kind = None
-        if USING_SQLACLCHEMY_20:
-            from sqlalchemy.engine.reflection import ObjectKind
-
-            kind = ObjectKind.ANY
+        kind = None if not USING_SQLACLCHEMY_20 else ObjectKind.ANY
         dict = self.get_multi_foreign_keys(
             connection, schema=schema, filter_names=[table_name], kind=kind
         )

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -776,6 +776,7 @@ ORDER BY
         dict=self.get_multi_indexes(
             connection, schema=schema, filter_names=[table_name]
         )
+        schema = None if schema == '' else schema
         return dict.get((schema, table_name), [])
 
     @engine_to_connection

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -655,7 +655,7 @@ class SpannerDialect(DefaultDialect):
     @engine_to_connection
     def get_view_names(self, connection, schema=None, **kw):
         """
-        Gets a list of view name.
+        Gets a list of view names.
 
         The method is used by SQLAlchemy introspection systems.
 

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -661,7 +661,6 @@ class SpannerDialect(DefaultDialect):
             result_dict = {}
 
             for col in columns:
-                columns = snap.execute_sql(sql)
                 column_info = {
                     "name": col[2],
                     "type": self._designate_type(col[3]),

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -39,7 +39,7 @@ from sqlalchemy.sql.compiler import (
 )
 from sqlalchemy.sql.default_comparator import operator_lookup
 from sqlalchemy.sql.operators import json_getitem_op
-from sqlalchemy.engine.reflection import ObjectKind, ObjectScope
+from sqlalchemy.engine.reflection import ObjectKind
 
 from google.cloud.spanner_v1.data_types import JsonObject
 from google.cloud import spanner_dbapi

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -674,6 +674,47 @@ ORDER BY
         else:
             return _type_map[str_repr]
 
+    # def _build_multi_index_query(self, schema, filter_names, scope, kind):
+
+
+    # @engine_to_connection
+    # def get_multi_indexes(self, connection, schema, filter_names, scope, kind, **kw):
+    #     sql = """
+    #         SELECT
+    #             i.index_name,
+    #             ARRAY_AGG(ic.column_name),
+    #             i.is_unique,
+    #             ARRAY_AGG(ic.column_ordering)
+    #         FROM information_schema.indexes as i
+    #         JOIN information_schema.index_columns AS ic
+    #             ON ic.index_name = i.index_name AND ic.table_name = i.table_name
+    #         WHERE
+    #             i.table_name="{table_name}"
+    #             AND i.index_type != 'PRIMARY_KEY'
+    #             AND i.spanner_is_managed = FALSE
+    #         GROUP BY i.index_name, i.is_unique
+    #         ORDER BY i.index_name
+    #     """.format(
+    #         table_name=table_name
+    #     )
+
+    #     ind_desc = []
+    #     with connection.connection.database.snapshot() as snap:
+    #         rows = snap.execute_sql(sql)
+
+    #         for row in rows:
+    #             ind_desc.append(
+    #                 {
+    #                     "name": row[0],
+    #                     "column_names": row[1],
+    #                     "unique": row[2],
+    #                     "column_sorting": {
+    #                         col: order for col, order in zip(row[1], row[3])
+    #                     },
+    #                 }
+    #             )
+    #     return ind_desc
+
     @engine_to_connection
     def get_indexes(self, connection, table_name, schema=None, **kw):
         """Get the table indexes.

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -885,6 +885,8 @@ ORDER BY
 
         sql = """
         SELECT
+            tc.table_name,
+            tc.table_schema,
             tc.constraint_name,
             ctu.table_name,
             ctu.table_schema,
@@ -907,7 +909,7 @@ ORDER BY
                 {table_filter_query}
                 tc.constraint_type = "FOREIGN KEY"
                 {schema_filter_query}
-            GROUP BY tc.constraint_name, ctu.table_name, ctu.table_schema
+            GROUP BY tc.table_name, tc.table_schema, tc.constraint_name, ctu.table_name, ctu.table_schema
             """.format(
             table_filter_query=table_filter_query,
             schema_filter_query=schema_filter_query,
@@ -930,22 +932,21 @@ ORDER BY
                 #
                 # The solution seem a bit clumsy, and should be improved as soon as a
                 # better approach found.
+                row[0] = row[0] or None
                 table_info = result_dict.get((row[0], row[1]), [])
-                for index, value in enumerate(sorted(row[4])):
-                    row[4][index] = value.split("_____")[1]
-
-                row[2] = row[2] or None 
+                for index, value in enumerate(sorted(row[6])):
+                    row[6][index] = value.split("_____")[1]
 
                 fk_info = {
-                    "name": row[0],
-                    "referred_table": row[1],
-                    "referred_schema": row[2],
-                    "referred_columns": row[3],
-                    "constrained_columns": row[4],
+                    "name": row[2],
+                    "referred_table": row[3],
+                    "referred_schema": row[4] or None,
+                    "referred_columns": row[5],
+                    "constrained_columns": row[6],
                 }
 
                 table_info.append(fk_info)
-                result_dict[(row[2], row[1])] = table_info
+                result_dict[(row[0], row[1])] = table_info
 
         return result_dict
 

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -52,7 +52,7 @@ if sqlalchemy.__version__.split(".")[0] == "2":
 
 
 @listens_for(Pool, "reset")
-def reset_connection(dbapi_conn, connection_record, reset_state):
+def reset_connection(dbapi_conn, connection_record, reset_state=None):
     """An event of returning a connection back to a pool."""
     if hasattr(dbapi_conn, "connection"):
         dbapi_conn = dbapi_conn.connection

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -626,12 +626,12 @@ class SpannerDialect(DefaultDialect):
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
         table_filter_query = ""
-        schema_filter_query = "AND i.table_schema = '{schema}'".format(
+        schema_filter_query = "AND table_schema = '{schema}'".format(
             schema=schema or ""
         )
         if filter_names is not None:
             for table_name in filter_names:
-                query = "i.table_name = '{table_name}'".format(table_name=table_name)
+                query = "table_name = '{table_name}'".format(table_name=table_name)
                 if table_filter_query != "":
                     table_filter_query = table_filter_query + " OR " + query
                 else:

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -964,6 +964,9 @@ class SpannerDialect(DefaultDialect):
                 for index, value in enumerate(sorted(row[6])):
                     row[6][index] = value.split("_____")[1]
 
+                # import pdb
+                # pdb.set_trace()
+
                 fk_info = {
                     "name": row[2],
                     "referred_table": row[3],

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -769,7 +769,7 @@ ORDER BY
         """
         return self.get_multi_indexes(
             connection, schema=schema, filter_names=[table_name]
-        )[table_name]
+        ).get(table_name, [])
 
     @engine_to_connection
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -39,7 +39,6 @@ from sqlalchemy.sql.compiler import (
 )
 from sqlalchemy.sql.default_comparator import operator_lookup
 from sqlalchemy.sql.operators import json_getitem_op
-from sqlalchemy.engine.reflection import ObjectKind
 
 from google.cloud.spanner_v1.data_types import JsonObject
 from google.cloud import spanner_dbapi
@@ -697,11 +696,6 @@ ORDER BY
     def get_multi_indexes(
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
-        unsupportedIndexObjectKind = [ObjectKind.MATERIALIZED_VIEW, ObjectKind.VIEW]
-        if kind is not None:
-            if kind in unsupportedIndexObjectKind:
-                raise ValueError("VIEW and MATERIALIZED_VIEW Indexes are not supported")
-
         table_filter_query = ""
         if filter_names is not None:
             for table_name in filter_names:

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -547,7 +547,7 @@ class SpannerDialect(DefaultDialect):
         Used to initiate connections to the Cloud Spanner databases.
         """
         return spanner_dbapi
-    
+
     @classmethod
     def import_dbapi(cls):
         """A pointer to the Cloud Spanner DB API package.
@@ -705,7 +705,9 @@ ORDER BY
         self, connection, schema=None, filter_names=None, scope=None, kind=None, **kw
     ):
         table_filter_query = ""
-        schema_filter_query = "AND i.table_schema = '{schema}'".format(schema=schema or "")
+        schema_filter_query = "AND i.table_schema = '{schema}'".format(
+            schema=schema or ""
+        )
         if filter_names is not None:
             for table_name in filter_names:
                 query = "i.table_name = '{table_name}'".format(table_name=table_name)
@@ -734,7 +736,8 @@ ORDER BY
             GROUP BY i.table_schema, i.table_name, i.index_name, i.is_unique
             ORDER BY i.index_name
         """.format(
-            table_filter_query=table_filter_query, schema_filter_query=schema_filter_query
+            table_filter_query=table_filter_query,
+            schema_filter_query=schema_filter_query,
         )
 
         with connection.connection.database.snapshot() as snap:
@@ -750,11 +753,10 @@ ORDER BY
                         col: order for col, order in zip(row[3], row[5])
                     },
                 }
-                row[0] = row[0] if row[0] != '' else None
+                row[0] = row[0] if row[0] != "" else None
                 table_info = result_dict.get((row[0], row[1]), [])
                 table_info.append(index_info)
-                result_dict[(row[0], row[1])]= table_info
-        
+                result_dict[(row[0], row[1])] = table_info
 
         return result_dict
 
@@ -773,10 +775,10 @@ ORDER BY
         Returns:
             list: List with indexes description.
         """
-        dict=self.get_multi_indexes(
+        dict = self.get_multi_indexes(
             connection, schema=schema, filter_names=[table_name]
         )
-        schema = None if schema == '' else schema
+        schema = None if schema == "" else schema
         return dict.get((schema, table_name), [])
 
     @engine_to_connection

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -886,8 +886,11 @@ class SpannerDialect(DefaultDialect):
                 ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
             JOIN information_schema.tables AS t
                 ON tc.table_name = t.table_name
+            JOIN information_schema.columns as c
+                ON c.column_name =ccu.COLUMN_NAME  and  c.table_name = tc.table_name
             WHERE {table_filter_query} tc.CONSTRAINT_TYPE = "PRIMARY KEY"
             {table_type_query} {schema_filter_query}
+            ORDER BY tc.CONSTRAINT_NAME, c.ORDINAL_POSITION
         """.format(
             table_filter_query=table_filter_query,
             table_type_query=table_type_query,

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -915,9 +915,6 @@ ORDER BY
             schema_filter_query=schema_filter_query,
         )
 
-        import pdb
-        pdb.set_trace()
-
         with connection.connection.database.snapshot() as snap:
             rows = list(snap.execute_sql(sql))
             result_dict = {}
@@ -951,8 +948,6 @@ ORDER BY
                 table_info.append(fk_info)
                 result_dict[(row[0], row[1])] = table_info
 
-        import pdb
-        pdb.set_trace()
         return result_dict
 
     @engine_to_connection

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -934,16 +934,18 @@ ORDER BY
                 for index, value in enumerate(sorted(row[4])):
                     row[4][index] = value.split("_____")[1]
 
+                row[2] = row[2] or None 
+
                 fk_info = {
                     "name": row[0],
                     "referred_table": row[1],
-                    "referred_schema": row[2] or None,
+                    "referred_schema": row[2],
                     "referred_columns": row[3],
                     "constrained_columns": row[4],
                 }
 
                 table_info.append(fk_info)
-                result_dict[(row[0], row[1])] = table_info
+                result_dict[(row[2], row[1])] = table_info
 
         return result_dict
 

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -886,11 +886,8 @@ class SpannerDialect(DefaultDialect):
                 ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
             JOIN information_schema.tables AS t
                 ON tc.table_name = t.table_name
-            JOIN information_schema.columns as c
-                ON c.column_name =ccu.COLUMN_NAME  and  c.table_name = tc.table_name
             WHERE {table_filter_query} tc.CONSTRAINT_TYPE = "PRIMARY KEY"
             {table_type_query} {schema_filter_query}
-            ORDER BY tc.CONSTRAINT_NAME, c.ORDINAL_POSITION
         """.format(
             table_filter_query=table_filter_query,
             table_type_query=table_type_query,

--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -885,8 +885,8 @@ ORDER BY
 
         sql = """
         SELECT
-            tc.table_name,
             tc.table_schema,
+            tc.table_name,
             tc.constraint_name,
             ctu.table_name,
             ctu.table_schema,
@@ -914,6 +914,9 @@ ORDER BY
             table_filter_query=table_filter_query,
             schema_filter_query=schema_filter_query,
         )
+
+        import pdb
+        pdb.set_trace()
 
         with connection.connection.database.snapshot() as snap:
             rows = list(snap.execute_sql(sql))
@@ -948,6 +951,8 @@ ORDER BY
                 table_info.append(fk_info)
                 result_dict[(row[0], row[1])] = table_info
 
+        import pdb
+        pdb.set_trace()
         return result_dict
 
     @engine_to_connection

--- a/noxfile.py
+++ b/noxfile.py
@@ -165,6 +165,7 @@ def compliance_test_13(session):
         "--cov-fail-under=0",
         "--asyncio-mode=auto",
         "test/test_suite_13.py",
+        *session.posargs,
     )
 
 
@@ -203,6 +204,7 @@ def compliance_test_14(session):
         "--cov-fail-under=0",
         "--asyncio-mode=auto",
         "test/test_suite_14.py",
+        *session.posargs,
     )
 
 
@@ -240,6 +242,7 @@ def compliance_test_20(session):
         "--cov-fail-under=0",
         "--asyncio-mode=auto",
         "test/test_suite_20.py",
+        *session.posargs,
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -210,9 +210,6 @@ def compliance_test_14(session):
 def compliance_test_20(session):
     """Run SQLAlchemy dialect compliance test suite."""
 
-    # Check the value of `RUN_COMPLIANCE_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_COMPLIANCE_TESTS", "true") == "false":
-        session.skip("RUN_COMPLIANCE_TESTS is set to false, skipping")
     # Sanity check: Only run tests if the environment variable is set.
     if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "") and not os.environ.get(
         "SPANNER_EMULATOR_HOST", ""

--- a/test.cfg
+++ b/test.cfg
@@ -1,0 +1,3 @@
+[db]
+default = spanner+spanner:///projects/span-cloud-testing/instances/sqlalchemy-test-1679343109715/databases/compliance-test
+

--- a/test.cfg
+++ b/test.cfg
@@ -1,3 +1,0 @@
-[db]
-default = spanner+spanner:///projects/span-cloud-testing/instances/sqlalchemy-test-1679343109715/databases/compliance-test
-

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -699,7 +699,9 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                     sqlalchemy.Index("noncol_idx_nopk", noncol_idx_test_nopk.c.q.desc())
                     sqlalchemy.Index("noncol_idx_pk", noncol_idx_test_pk.c.q.desc())
 
-        if testing.requires.view_column_reflection.enabled:
+        if testing.requires.view_column_reflection.enabled and not bool(
+            os.environ.get("SPANNER_EMULATOR_HOST")
+        ):
             cls.define_views(metadata, schema)
         if not schema and testing.requires.temp_table_reflection.enabled:
             cls.define_temp_tables(metadata)

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -979,7 +979,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (
-            ["id", "attr", "name"]
+            ['id', 'name', 'attr']
             if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
             else ["name", "id", "attr"]
         )

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -973,7 +973,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
     def test_pk_column_order(self, connection):
         """
         SPANNER OVERRIDE:
-        Emultor is not able to return pk sorted by ordinal value
+        Emultor doesn't support returning pk sorted by ordinal value
         of columns.
         """
         insp = inspect(connection)

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -979,7 +979,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (
-            ['id', 'name', 'attr']
+            ["id", "name", "attr"]
             if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
             else ["name", "id", "attr"]
         )

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -526,12 +526,6 @@ class UnicodeTextTest(UnicodeFixtureTest, _UnicodeTextTest):
 
 
 class ComponentReflectionTest(_ComponentReflectionTest):
-    def quote_fixtures(fn):
-        return testing.combinations(
-            ("quote ' one",),
-            ('quote " two', testing.requires.symbol_names_w_double_quote),
-        )(fn)
-
     @classmethod
     def define_views(cls, metadata, schema):
         table_info = {

--- a/test/test_suite_13.py
+++ b/test/test_suite_13.py
@@ -969,6 +969,22 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         eq_(set(fkey1.get("referred_columns")), {"name", "id", "attr"})
         eq_(set(fkey1.get("constrained_columns")), {"pname", "pid", "pattr"})
 
+    @testing.requires.primary_key_constraint_reflection
+    def test_pk_column_order(self, connection):
+        """
+        SPANNER OVERRIDE:
+        Emultor is not able to return pk sorted by ordinal value
+        of columns.
+        """
+        insp = inspect(connection)
+        primary_key = insp.get_pk_constraint(self.tables.tb1.name)
+        exp = (
+            ["id", "attr", "name"]
+            if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
+            else ["name", "id", "attr"]
+        )
+        eq_(primary_key.get("constrained_columns"), exp)
+
 
 class RowFetchTest(_RowFetchTest):
     def test_row_w_scalar_select(self):

--- a/test/test_suite_14.py
+++ b/test/test_suite_14.py
@@ -736,7 +736,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (
-            ["id", "attr", "name"]
+            ['id', 'name', 'attr']
             if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
             else ["name", "id", "attr"]
         )

--- a/test/test_suite_14.py
+++ b/test/test_suite_14.py
@@ -730,6 +730,18 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         eq_(set(fkey1.get("referred_columns")), {"name", "id", "attr"})
         eq_(set(fkey1.get("constrained_columns")), {"pname", "pid", "pattr"})
 
+    @testing.requires.primary_key_constraint_reflection
+    def test_pk_column_order(self, connection):
+        # test for issue #5661
+        insp = inspect(connection)
+        primary_key = insp.get_pk_constraint(self.tables.tb1.name)
+        exp = (
+            ["id", "attr", "name"]
+            if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
+            else ["name", "id", "attr"]
+        )
+        eq_(primary_key.get("constrained_columns"), exp)
+
 
 @pytest.mark.skip("Spanner doesn't support quotes in table names.")
 class QuotedNameArgumentTest(_QuotedNameArgumentTest):

--- a/test/test_suite_14.py
+++ b/test/test_suite_14.py
@@ -732,7 +732,11 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
 
     @testing.requires.primary_key_constraint_reflection
     def test_pk_column_order(self, connection):
-        # test for issue #5661
+        """
+        SPANNER OVERRIDE:
+        Emultor doesn't support returning pk sorted by ordinal value
+        of columns.
+        """
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (

--- a/test/test_suite_14.py
+++ b/test/test_suite_14.py
@@ -736,7 +736,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (
-            ['id', 'name', 'attr']
+            ["id", "name", "attr"]
             if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
             else ["name", "id", "attr"]
         )

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -771,8 +771,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             self.exp_fks,
         )
         for kw in kws:
-            import pdb
-            pdb.set_trace()
             insp.clear_cache()
             result = insp.get_multi_foreign_keys(**kw)
             self._adjust_sort(result, exp, lambda d: tuple(d["constrained_columns"]))
@@ -1996,6 +1994,9 @@ class StringTest(_StringTest):
                 connection.scalars(select(t.c.x).where(t.c.x.like(args[0]))).all(),
                 args[1],
             )
+        
+        t.drop(connection)
+        connection.connection.commit()
 
 
 class TextTest(_TextTest):

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -76,7 +76,23 @@ from sqlalchemy.testing.suite.test_reflection import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_deprecations import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_results import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_types import *  # noqa: F401, F403
-from sqlalchemy.testing.suite.test_select import *  # noqa: F401, F403
+from sqlalchemy.testing.suite.test_select import (
+    IsOrIsNotDistinctFromTest,
+    DistinctOnTest,
+    ExistsTest,
+    IdentityAutoincrementTest,
+    IdentityColumnTest,
+    LikeFunctionsTest,
+    ExpandingBoundInTest,
+    ComputedColumnTest,
+    PostCompileParamsTest,
+    CompoundSelectTest,
+    JoinTest,
+    FetchLimitOffsetTest,
+    ValuesExpressionTest,
+    OrderByLabelTest,
+    CollateTest
+)  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_sequence import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_unicode_ddl import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_update_delete import *  # noqa: F401, F403
@@ -2252,7 +2268,7 @@ class JSONTest(_JSONTest):
 
 
 class ExecutionOptionsRequestPriorotyTest(fixtures.TestBase):
-    def setUp(self, connection):
+    def test_request_priority(self, connection):
         self._engine = create_engine(get_db_url(), pool_size=1)
         metadata = MetaData()
 
@@ -2265,8 +2281,6 @@ class ExecutionOptionsRequestPriorotyTest(fixtures.TestBase):
 
         metadata.create_all(connection)
         time.sleep(1)
-
-    def test_request_priority(self):
         PRIORITY = RequestOptions.Priority.PRIORITY_MEDIUM
         with self._engine.connect().execution_options(
             request_priority=PRIORITY

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -70,7 +70,17 @@ from google.cloud import spanner_dbapi
 
 from sqlalchemy.testing.suite.test_cte import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_ddl import *  # noqa: F401, F403
-from sqlalchemy.testing.suite.test_dialect import *  # noqa: F401, F403
+from sqlalchemy.testing.suite.test_dialect import (
+    PingTest,
+    ArgSignatureTest,
+    ExceptionTest,
+    IsolationLevelTest,
+    AutocommitIsolationTest,
+    EscapingTest,
+    WeCanSetDefaultSchemaWEventsTest,
+    FutureWeCanSetDefaultSchemaWEventsTest,
+    DifficultParametersTest
+)  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_insert import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_reflection import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_deprecations import *  # noqa: F401, F403

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1517,7 +1517,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (
-            ['id', 'name', 'attr']
+            ["id", "name", "attr"]
             if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
             else ["name", "id", "attr"]
         )

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -384,7 +384,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class AAAAComponentReflectionTest(_ComponentReflectionTest):
+class ComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
@@ -529,7 +529,6 @@ class AAAAComponentReflectionTest(_ComponentReflectionTest):
                 noncol_idx_test_nopk = Table(
                     "noncol_idx_test_nopk",
                     metadata,
-                    Column("id", sqlalchemy.Integer, primary_key=True),
                     Column("q", sqlalchemy.String(5)),
                     test_needs_fk=True,
                     extend_existing=True,

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -383,7 +383,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class AAAAAComponentReflectionTest(_ComponentReflectionTest):
+class ComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
@@ -672,8 +672,6 @@ class AAAAAComponentReflectionTest(_ComponentReflectionTest):
     @testing.combinations((False,), argnames="use_schema")
     @testing.requires.foreign_key_constraint_reflection
     def test_get_foreign_keys(self, connection, use_schema):
-        import pdb
-        pdb.set_trace()
         if use_schema:
             schema = config.test_schema
         else:

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -383,7 +383,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class AAAAAComponentReflectionTest(_ComponentReflectionTest):
+class ComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
@@ -683,8 +683,6 @@ class AAAAAComponentReflectionTest(_ComponentReflectionTest):
         # users
 
         if testing.requires.self_referential_foreign_keys.enabled:
-            import pdb
-            pdb.set_trace()
             users_fkeys = insp.get_foreign_keys(users.name, schema=schema)
             fkey1 = users_fkeys[0]
 

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -559,6 +559,15 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         scope=ObjectScope.DEFAULT,
         kind=ObjectKind.TABLE,
     ):
+        """
+        SPANNER OVERRIDE:
+
+        Spanner doesn't support indexes on views and
+        doesn't support temporary tables, so real tables are
+        used for testing. As the original test expects only real
+        tables to be read, and in Spanner all the tables are real,
+        expected results override is required.
+        """
         insp, kws, exp = get_multi_exp(
             schema,
             scope,
@@ -567,12 +576,13 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             Inspector.get_indexes,
             self.exp_indexes,
         )
-        tables_with_indexes = [
-            (None, "noncol_idx_test_nopk"),
-            (None, "noncol_idx_test_pk"),
-            (None, "users"),
+        _ignore_tables = [
+            (None, "comment_test"),
+            (None, "dingalings"),
+            (None, "email_addresses"),
+            (None, "no_constraints"),
         ]
-        exp = {k: v for k, v in exp.items() if k in tables_with_indexes}
+        exp = {k: v for k, v in exp.items() if k not in _ignore_tables}
 
         for kw in kws:
             insp.clear_cache()
@@ -588,6 +598,14 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         scope=ObjectScope.DEFAULT,
         kind=ObjectKind.TABLE,
     ):
+        """
+        SPANNER OVERRIDE:
+
+        Spanner doesn't support temporary tables, so real tables are
+        used for testing. As the original test expects only real
+        tables to be read, and in Spanner all the tables are real,
+        expected results override is required.
+        """
         insp, kws, exp = get_multi_exp(
             schema,
             scope,
@@ -596,6 +614,9 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             Inspector.get_pk_constraint,
             self.exp_pks,
         )
+        _ignore_tables = [(None, 'no_constraints')]
+        exp = {k: v for k, v in exp.items() if k not in _ignore_tables}
+        
         for kw in kws:
             insp.clear_cache()
             result = insp.get_multi_pk_constraint(**kw)

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1517,7 +1517,7 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (
-            ["id", "attr", "name"]
+            ['id', 'name', 'attr']
             if bool(os.environ.get("SPANNER_EMULATOR_HOST"))
             else ["name", "id", "attr"]
         )

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1754,15 +1754,13 @@ class StringTest(_StringTest):
         t.create(connection)
         connection.connection.commit()
 
+        connection.execute(t.delete())
         connection.execute(t.insert(), [{"x": "AB"}, {"x": "BC"}, {"x": "AC"}])
 
         eq_(
             connection.scalars(select(t.c.x).where(t.c.x.like(expr))).all(),
             expected,
         )
-
-        t.drop()
-        connection.connection.commit()
 
 
 class TextTest(_TextTest):

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -387,7 +387,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class AAAAAComponentReflectionTest(_ComponentReflectionTest):
+class ComponentReflectionTest(_ComponentReflectionTest):
     @classmethod
     def define_tables(cls, metadata):
         cls.define_reflected_tables(metadata, None)

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -207,6 +207,7 @@ class BooleanTest(_BooleanTest):
 
 
 class ComponentReflectionTestExtra(_ComponentReflectionTestExtra):
+    @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
 
@@ -328,22 +329,6 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         filter_names = testing.combinations(True, False, argnames="use_filter")
 
         return schema(scope(kind(filter_names(fn))))
-
-    @testing.requires.index_reflection
-    @_multi_combination
-    def test_get_multi_indexes(self, get_multi_exp, schema, scope, kind, use_filter):
-        insp, kws, exp = get_multi_exp(
-            schema,
-            scope,
-            kind,
-            use_filter,
-            Inspector.get_indexes,
-            self.exp_indexes,
-        )
-        for kw in kws:
-            insp.clear_cache()
-            result = insp.get_multi_indexes(**kw)
-            self._check_table_dict(result, exp, self._required_index_keys)
 
     @testing.requires.schemas
     def test_get_column_returns_persisted_with_schema(self):
@@ -599,12 +584,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
     def test_get_multi_foreign_keys():
-        pass
-
-    @pytest.mark.skip(
-        "Requires an introspection method to be implemented in SQLAlchemy first"
-    )
-    def test_get_multi_indexes():
         pass
 
     @pytest.mark.skip(

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1760,6 +1760,8 @@ class StringTest(_StringTest):
             connection.scalars(select(t.c.x).where(t.c.x.like(expr))).all(),
             expected,
         )
+        
+        t.drop()
 
 
 class TextTest(_TextTest):

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1810,7 +1810,7 @@ class ReturningGuardsTest(_ReturningGuardsTest):
 
 
 @pytest.mark.skip("Spanner doesn't support user made schemas")
-class SameNamedSchemaTableTestt(_SameNamedSchemaTableTest):
+class SameNamedSchemaTableTest(_SameNamedSchemaTableTest):
     pass
 
 

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -382,7 +382,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class AAAAComponentReflectionTest(_ComponentReflectionTest):
+class ComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -25,7 +25,7 @@ import time
 from unittest import mock
 
 from google.cloud.spanner_v1 import RequestOptions
-
+from sqlalchemy.testing.assertions import is_
 import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Inspector
@@ -387,7 +387,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class ComponentReflectionTest(_ComponentReflectionTest):
+class AAAAAComponentReflectionTest(_ComponentReflectionTest):
     @classmethod
     def define_tables(cls, metadata):
         cls.define_reflected_tables(metadata, None)
@@ -562,6 +562,9 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             Inspector.get_indexes,
             self.exp_indexes,
         )
+        tables_with_indexes = [(None, 'noncol_idx_test_nopk'), (None, 'noncol_idx_test_pk'), (None, 'users')]
+        exp = {k: v for k, v in exp.items() if k in tables_with_indexes}
+
         for kw in kws:
             insp.clear_cache()
             result = insp.get_multi_indexes(**kw)

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1741,6 +1741,26 @@ class StringTest(_StringTest):
     def test_literal_non_ascii(self):
         pass
 
+    @testing.combinations(
+        ("%B%", ["AB", "BC"]),
+        ("A%C", ["AC"]),
+        ("A%C%Z", []),
+        argnames="expr, expected",
+    )
+    def test_dont_truncate_rightside(
+        self, metadata, connection, expr, expected
+    ):
+        t = Table("t", metadata, Column("x", String(2)))
+        t.create(connection)
+        connection.connection.commit()
+
+        connection.execute(t.insert(), [{"x": "AB"}, {"x": "BC"}, {"x": "AC"}])
+
+        eq_(
+            connection.scalars(select(t.c.x).where(t.c.x.like(expr))).all(),
+            expected,
+        )
+
 
 class TextTest(_TextTest):
     @classmethod

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1744,7 +1744,7 @@ class StringTest(_StringTest):
     def test_dont_truncate_rightside(
         self, metadata, connection, expr=None, expected=None
     ):
-        t = Table("t", metadata, Column("x", String(2)))
+        t = Table("t2", metadata, Column("x", String(2)))
         t.create(connection)
         connection.connection.commit()
         connection.execute(t.insert(), [{"x": "AB"}, {"x": "BC"}, {"x": "AC"}])

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -582,7 +582,11 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @filter_name_values()
     @testing.requires.primary_key_constraint_reflection
     def test_get_multi_pk_constraint(
-        self, get_multi_exp, schema, scope, kind, use_filter
+        self, get_multi_exp, 
+        use_filter,
+        schema=None,
+        scope=ObjectScope.DEFAULT,
+        kind=ObjectKind.TABLE,
     ):
         insp, kws, exp = get_multi_exp(
             schema,

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -383,7 +383,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class ComponentReflectionTest(_ComponentReflectionTest):
+class AAAAAComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
@@ -683,6 +683,8 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         # users
 
         if testing.requires.self_referential_foreign_keys.enabled:
+            import pdb
+            pdb.set_trace()
             users_fkeys = insp.get_foreign_keys(users.name, schema=schema)
             fkey1 = users_fkeys[0]
 

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -582,12 +582,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip(
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
-    def test_get_multi_indexes():
-        pass
-
-    @pytest.mark.skip(
-        "Requires an introspection method to be implemented in SQLAlchemy first"
-    )
     def test_get_multi_foreign_keys():
         pass
 

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -25,7 +25,6 @@ import time
 from unittest import mock
 
 from google.cloud.spanner_v1 import RequestOptions
-from sqlalchemy.testing.assertions import is_
 import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Inspector
@@ -63,7 +62,6 @@ from sqlalchemy.types import Numeric
 from sqlalchemy.types import Text
 from sqlalchemy.testing import requires
 from sqlalchemy.testing import is_true
-from sqlalchemy import exc
 from sqlalchemy import Index
 from sqlalchemy.testing.fixtures import (
     ComputedReflectionFixtureTest as _ComputedReflectionFixtureTest,
@@ -529,7 +527,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                 noncol_idx_test_nopk = Table(
                     "noncol_idx_test_nopk",
                     metadata,
-                    Column("q", sqlalchemy.String(5)),
+                    Column("q", sqlalchemy.String(5), primary_key=True),
                     test_needs_fk=True,
                     extend_existing=True,
                 )

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -579,16 +579,30 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             result = insp.get_multi_indexes(**kw)
             self._check_table_dict(result, exp, self._required_index_keys)
 
-    @pytest.mark.skip(
-        "Requires an introspection method to be implemented in SQLAlchemy first"
-    )
-    def test_get_multi_columns():
-        pass
+    @filter_name_values()
+    @testing.requires.primary_key_constraint_reflection
+    def test_get_multi_pk_constraint(
+        self, get_multi_exp, schema, scope, kind, use_filter
+    ):
+        insp, kws, exp = get_multi_exp(
+            schema,
+            scope,
+            kind,
+            use_filter,
+            Inspector.get_pk_constraint,
+            self.exp_pks,
+        )
+        for kw in kws:
+            insp.clear_cache()
+            result = insp.get_multi_pk_constraint(**kw)
+            self._check_table_dict(
+                result, exp, self._required_pk_keys, make_lists=True
+            )
 
     @pytest.mark.skip(
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
-    def test_get_multi_pk_constraint():
+    def test_get_multi_columns():
         pass
 
     @pytest.mark.skip(

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -901,13 +901,13 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         pass
 
     def _check_list(self, result, exp, req_keys=None, msg=None, index=False):
-        try:
+        if result is not None and hasattr(result[0], 'name'):
             exp.sort(key=lambda item: item["name"])
 
             index_names = [d["name"] for d in result]
             exp_index_names = [d["name"] for d in exp]
             assert sorted(index_names) == sorted(exp_index_names)
-        except:
+        else:
             if req_keys is None:
                 eq_(result, exp, msg)
             else:

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1760,8 +1760,9 @@ class StringTest(_StringTest):
             connection.scalars(select(t.c.x).where(t.c.x.like(expr))).all(),
             expected,
         )
-        
+
         t.drop()
+        connection.connection.commit()
 
 
 class TextTest(_TextTest):

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -383,7 +383,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class ComponentReflectionTest(_ComponentReflectionTest):
+class AAAAAComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
@@ -672,6 +672,8 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @testing.combinations((False,), argnames="use_schema")
     @testing.requires.foreign_key_constraint_reflection
     def test_get_foreign_keys(self, connection, use_schema):
+        import pdb
+        pdb.set_trace()
         if use_schema:
             schema = config.test_schema
         else:

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1008,6 +1008,19 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         res = self._resolve_kind(kind, tables, views, materialized)
         res = self._resolve_names(schema, scope, filter_names, res)
         return res
+    
+    def _check_list(self, result, exp, req_keys=None, msg=None):
+        if req_keys is None:
+            eq_(result, exp, msg)
+        else:
+            eq_(len(result), len(exp), msg)
+            for r, e in zip(result, exp):
+                for k in set(r) | set(e):
+                    if (k in req_keys and (k in r and k in e)) or (k in r and k in e):
+                        if isinstance(r[k],list):
+                            r[k].sort()
+                            e[k].sort()
+                        eq_(r[k], e[k], f"{msg} - {k} - {r}")
 
     @testing.combinations(True, False, argnames="use_schema")
     @testing.combinations(

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1741,26 +1741,25 @@ class StringTest(_StringTest):
     def test_literal_non_ascii(self):
         pass
 
-    @testing.combinations(
-        ("%B%", ["AB", "BC"]),
-        ("A%C", ["AC"]),
-        ("A%C%Z", []),
-        argnames="expr, expected",
-    )
     def test_dont_truncate_rightside(
-        self, metadata, connection, expr, expected
+        self, metadata, connection, expr=None, expected=None
     ):
         t = Table("t", metadata, Column("x", String(2)))
         t.create(connection)
         connection.connection.commit()
-
-        connection.execute(t.delete())
         connection.execute(t.insert(), [{"x": "AB"}, {"x": "BC"}, {"x": "AC"}])
 
-        eq_(
-            connection.scalars(select(t.c.x).where(t.c.x.like(expr))).all(),
-            expected,
-        )
+        combinations =[
+            ("%B%", ["AB", "BC"]),
+            ("A%C", ["AC"]),
+            ("A%C%Z", [])
+        ]
+
+        for args in combinations:
+            eq_(
+                connection.scalars(select(t.c.x).where(t.c.x.like(args[0]))).all(),
+                args[1],
+            )
 
 
 class TextTest(_TextTest):

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -552,7 +552,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @filter_name_values()
     @testing.requires.index_reflection
     def test_get_multi_indexes(
-        self, get_multi_exp, schema , use_filter, scope=ObjectScope.DEFAULT, kind=ObjectKind.TABLE
+        self, get_multi_exp , use_filter, schema=None, scope=ObjectScope.DEFAULT, kind=ObjectKind.TABLE
     ):
         insp, kws, exp = get_multi_exp(
             schema,

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -592,7 +592,8 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @filter_name_values()
     @testing.requires.primary_key_constraint_reflection
     def test_get_multi_pk_constraint(
-        self, get_multi_exp, 
+        self,
+        get_multi_exp,
         use_filter,
         schema=None,
         scope=ObjectScope.DEFAULT,
@@ -614,26 +615,42 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             Inspector.get_pk_constraint,
             self.exp_pks,
         )
-        _ignore_tables = [(None, 'no_constraints')]
+        _ignore_tables = [(None, "no_constraints")]
         exp = {k: v for k, v in exp.items() if k not in _ignore_tables}
-        
+
         for kw in kws:
             insp.clear_cache()
             result = insp.get_multi_pk_constraint(**kw)
-            self._check_table_dict(
-                result, exp, self._required_pk_keys, make_lists=True
-            )
+            self._check_table_dict(result, exp, self._required_pk_keys, make_lists=True)
+
+    @filter_name_values()
+    @testing.requires.foreign_key_constraint_reflection
+    def test_get_multi_foreign_keys(
+        self,
+        get_multi_exp,
+        use_filter,
+        schema=None,
+        scope=ObjectScope.DEFAULT,
+        kind=ObjectKind.TABLE,
+    ):
+        insp, kws, exp = get_multi_exp(
+            schema,
+            scope,
+            kind,
+            use_filter,
+            Inspector.get_foreign_keys,
+            self.exp_fks,
+        )
+        for kw in kws:
+            insp.clear_cache()
+            result = insp.get_multi_foreign_keys(**kw)
+            self._adjust_sort(result, exp, lambda d: tuple(d["constrained_columns"]))
+            self._check_table_dict(result, exp, self._required_fk_keys)
 
     @pytest.mark.skip(
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
     def test_get_multi_columns():
-        pass
-
-    @pytest.mark.skip(
-        "Requires an introspection method to be implemented in SQLAlchemy first"
-    )
-    def test_get_multi_foreign_keys():
         pass
 
     @pytest.mark.skip(

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -85,7 +85,6 @@ from sqlalchemy.testing.suite.test_insert import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_reflection import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_deprecations import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_results import *  # noqa: F401, F403
-from sqlalchemy.testing.suite.test_types import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_select import (
     IsOrIsNotDistinctFromTest,
     DistinctOnTest,

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,28 +74,12 @@ from google.cloud import spanner_dbapi
 
 from sqlalchemy.testing.suite.test_cte import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_ddl import *  # noqa: F401, F403
-from sqlalchemy.testing.suite.test_dialect import (  # noqa: F401, F403
-    PingTest,
-    ArgSignatureTest,
-    ExceptionTest,
-    IsolationLevelTest,
-    AutocommitIsolationTest,
-    WeCanSetDefaultSchemaWEventsTest,
-    FutureWeCanSetDefaultSchemaWEventsTest,
-)
+from sqlalchemy.testing.suite.test_dialect import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_insert import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_reflection import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_deprecations import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_results import *  # noqa: F401, F403
-from sqlalchemy.testing.suite.test_select import (  # noqa: F401, F403
-    DistinctOnTest,
-    IdentityColumnTest,
-    ExpandingBoundInTest,
-    ComputedColumnTest,
-    JoinTest,
-    ValuesExpressionTest,
-    CollateTest,
-)
+from sqlalchemy.testing.suite.test_select import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_sequence import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_unicode_ddl import *  # noqa: F401, F403
 from sqlalchemy.testing.suite.test_update_delete import *  # noqa: F401, F403
@@ -111,6 +95,7 @@ from sqlalchemy.testing.suite.test_update_delete import (
 from sqlalchemy.testing.suite.test_dialect import (
     DifficultParametersTest as _DifficultParametersTest,
     EscapingTest as _EscapingTest,
+    ReturningGuardsTest as _ReturningGuardsTest,
 )
 from sqlalchemy.testing.suite.test_insert import (
     InsertBehaviorTest as _InsertBehaviorTest,
@@ -124,6 +109,7 @@ from sqlalchemy.testing.suite.test_select import (  # noqa: F401, F403
     LikeFunctionsTest as _LikeFunctionsTest,
     OrderByLabelTest as _OrderByLabelTest,
     PostCompileParamsTest as _PostCompileParamsTest,
+    SameNamedSchemaTableTest as _SameNamedSchemaTableTest,
 )
 from sqlalchemy.testing.suite.test_reflection import (  # noqa: F401, F403
     ComponentReflectionTestExtra as _ComponentReflectionTestExtra,
@@ -1815,6 +1801,16 @@ class FetchLimitOffsetTest(_FetchLimitOffsetTest):
 
 @pytest.mark.skip("Spanner doesn't support autoincrement")
 class IdentityAutoincrementTest(_IdentityAutoincrementTest):
+    pass
+
+
+@pytest.mark.skip("Spanner doesn't support returning")
+class ReturningGuardsTest(_ReturningGuardsTest):
+    pass
+
+
+@pytest.mark.skip("Spanner doesn't support user made schemas")
+class SameNamedSchemaTableTestt(_SameNamedSchemaTableTest):
     pass
 
 

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -384,7 +384,7 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
         metadata.create_all(connection)
 
 
-class ComponentReflectionTest(_ComponentReflectionTest):
+class AAAAComponentReflectionTest(_ComponentReflectionTest):
     @pytest.mark.skip("Skip")
     def test_not_existing_table(self, method, connection):
         pass
@@ -436,6 +436,11 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                 "address_id",
                 sqlalchemy.Integer,
                 sqlalchemy.ForeignKey("%semail_addresses.address_id" % schema_prefix),
+            ),
+            Column(
+                "id_user",
+                sqlalchemy.Integer,
+                sqlalchemy.ForeignKey("%susers.user_id" % schema_prefix),
             ),
             Column("data", sqlalchemy.String(30)),
             schema=schema,
@@ -681,10 +686,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
     def test_get_multi_check_constraints():
-        pass
-
-    @pytest.mark.skip("Spanner must add support of the feature first")
-    def test_get_view_names():
         pass
 
     @testing.combinations((False,), argnames="use_schema")

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -307,28 +307,6 @@ class ComputedReflectionFixtureTest(_ComputedReflectionFixtureTest):
 
 
 class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureTest):
-    def filter_name_values():
-
-        return  testing.combinations(True, False, argnames="use_filter")
-
-    @filter_name_values()
-    @testing.requires.index_reflection
-    def test_get_multi_indexes(
-        self, get_multi_exp, schema , use_filter, scope=ObjectScope.DEFAULT, kind=ObjectKind.TABLE
-    ):
-        insp, kws, exp = get_multi_exp(
-            schema,
-            scope,
-            kind,
-            use_filter,
-            Inspector.get_indexes,
-            self.exp_indexes,
-        )
-        for kw in kws:
-            insp.clear_cache()
-            result = insp.get_multi_indexes(**kw)
-            self._check_table_dict(result, exp, self._required_index_keys)
-
     @testing.requires.schemas
     def test_get_column_returns_persisted_with_schema(self):
         insp = inspect(config.db)
@@ -567,6 +545,28 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         if testing.requires.view_column_reflection.enabled:
             cls.define_views(metadata, schema)
 
+    def filter_name_values():
+
+        return  testing.combinations(True, False, argnames="use_filter")
+
+    @filter_name_values()
+    @testing.requires.index_reflection
+    def test_get_multi_indexes(
+        self, get_multi_exp, schema , use_filter, scope=ObjectScope.DEFAULT, kind=ObjectKind.TABLE
+    ):
+        insp, kws, exp = get_multi_exp(
+            schema,
+            scope,
+            kind,
+            use_filter,
+            Inspector.get_indexes,
+            self.exp_indexes,
+        )
+        for kw in kws:
+            insp.clear_cache()
+            result = insp.get_multi_indexes(**kw)
+            self._check_table_dict(result, exp, self._required_index_keys)
+    
     @pytest.mark.skip(
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
@@ -577,6 +577,12 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )
     def test_get_multi_pk_constraint():
+        pass
+
+    @pytest.mark.skip(
+        "Requires an introspection method to be implemented in SQLAlchemy first"
+    )
+    def test_get_multi_indexes():
         pass
 
     @pytest.mark.skip(

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -881,6 +881,15 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         scope=ObjectScope.DEFAULT,
         kind=ObjectKind.TABLE,
     ):
+
+        """
+        SPANNER OVERRIDE:
+
+        Spanner doesn't support temporary tables, so real tables are
+        used for testing. As the original test expects only real
+        tables to be read, and in Spanner all the tables are real,
+        expected results override is required.
+        """
         insp, kws, exp = get_multi_exp(
             schema,
             scope,
@@ -1007,6 +1016,14 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         scope=ObjectScope.DEFAULT,
         kind=ObjectKind.TABLE,
     ):
+        """
+        SPANNER OVERRIDE:
+
+        Spanner doesn't support temporary tables, so real tables are
+        used for testing. As the original test expects only real
+        tables to be read, and in Spanner all the tables are real,
+        expected results override is required.
+        """
         insp, kws, exp = get_multi_exp(
             schema,
             scope,
@@ -1513,7 +1530,11 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
 
     @testing.requires.primary_key_constraint_reflection
     def test_pk_column_order(self, connection):
-        # test for issue #5661
+        """
+        SPANNER OVERRIDE:
+        Emultor doesn't support returning pk sorted by ordinal value
+        of columns.
+        """
         insp = inspect(connection)
         primary_key = insp.get_pk_constraint(self.tables.tb1.name)
         exp = (

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -902,7 +902,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @testing.combinations(
         (True, testing.requires.views), False, argnames="views"
     )
-    def test_aaaaametadata(self, connection, use_schema, views):
+    def test_metadata(self, connection, use_schema, views):
         m = MetaData()
         schema = config.test_schema if use_schema else None
         m.reflect(connection, schema=schema, views=views, resolve_fks=False)

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -527,7 +527,8 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                 noncol_idx_test_nopk = Table(
                     "noncol_idx_test_nopk",
                     metadata,
-                    Column("q", sqlalchemy.String(5), primary_key=True),
+                    Column("id", sqlalchemy.Integer, primary_key=True),
+                    Column("q", sqlalchemy.String(5)),
                     test_needs_fk=True,
                     extend_existing=True,
                 )
@@ -628,7 +629,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             (schema, "local_table"): pk("id"),
             (schema, "remote_table"): pk("id"),
             (schema, "remote_table_2"): pk("id"),
-            (schema, "noncol_idx_test_nopk"): pk("q"),
+            (schema, "noncol_idx_test_nopk"): pk("id"),
             (schema, "noncol_idx_test_pk"): pk("id"),
             (schema, self.temp_table_name()): pk("id"),
         }
@@ -721,7 +722,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                     ["address_id"],
                     ["address_id"],
                     "email_addresses",
-                    name="zz_email_add_id_fg",
+                    name="FK_dingalings_email_addresses_69EDC2F1F8F407B7_1",
                     comment="di fk comment",
                 ),
             ],
@@ -860,7 +861,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             (schema, "local_table"): [pk("id"), col("data"), col("remote_id")],
             (schema, "remote_table"): [pk("id"), col("local_id"), col("data")],
             (schema, "remote_table_2"): [pk("id"), col("data")],
-            (schema, "noncol_idx_test_nopk"): [pk("q")],
+            (schema, "noncol_idx_test_nopk"): [pk("id"), col("q")],
             (schema, "noncol_idx_test_pk"): [pk("id"), col("q")],
             (schema, self.temp_table_name()): [
                 pk("id"),
@@ -1209,6 +1210,13 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             else:
                 answer = ["dingalings", "email_addresses", "user_tmp", "users"]
                 eq_(sorted(table_names), answer)
+
+    @pytest.mark.skipif(
+        bool(os.environ.get("SPANNER_EMULATOR_HOST")), reason="Skipped on emulator"
+    )
+    def test_get_view_names(self):
+        super().test_get_view_names()
+
 
     @pytest.mark.skip("Spanner doesn't support temporary tables")
     def test_get_temp_table_indexes(self):

--- a/test/test_suite_20.py
+++ b/test/test_suite_20.py
@@ -207,10 +207,6 @@ class BooleanTest(_BooleanTest):
 
 
 class ComponentReflectionTestExtra(_ComponentReflectionTestExtra):
-    @pytest.mark.skip("Skip")
-    def test_not_existing_table(self, method, connection):
-        pass
-
     @testing.requires.table_reflection
     def test_nullable_reflection(self, connection, metadata):
         t = Table(
@@ -388,6 +384,10 @@ class ComputedReflectionTest(_ComputedReflectionTest, ComputedReflectionFixtureT
 
 
 class ComponentReflectionTest(_ComponentReflectionTest):
+    @pytest.mark.skip("Skip")
+    def test_not_existing_table(self, method, connection):
+        pass
+
     @classmethod
     def define_tables(cls, metadata):
         cls.define_reflected_tables(metadata, None)
@@ -547,12 +547,17 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
     def filter_name_values():
 
-        return  testing.combinations(True, False, argnames="use_filter")
+        return testing.combinations(True, False, argnames="use_filter")
 
     @filter_name_values()
     @testing.requires.index_reflection
     def test_get_multi_indexes(
-        self, get_multi_exp , use_filter, schema=None, scope=ObjectScope.DEFAULT, kind=ObjectKind.TABLE
+        self,
+        get_multi_exp,
+        use_filter,
+        schema=None,
+        scope=ObjectScope.DEFAULT,
+        kind=ObjectKind.TABLE,
     ):
         insp, kws, exp = get_multi_exp(
             schema,
@@ -562,14 +567,18 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             Inspector.get_indexes,
             self.exp_indexes,
         )
-        tables_with_indexes = [(None, 'noncol_idx_test_nopk'), (None, 'noncol_idx_test_pk'), (None, 'users')]
+        tables_with_indexes = [
+            (None, "noncol_idx_test_nopk"),
+            (None, "noncol_idx_test_pk"),
+            (None, "users"),
+        ]
         exp = {k: v for k, v in exp.items() if k in tables_with_indexes}
 
         for kw in kws:
             insp.clear_cache()
             result = insp.get_multi_indexes(**kw)
             self._check_table_dict(result, exp, self._required_index_keys)
-    
+
     @pytest.mark.skip(
         "Requires an introspection method to be implemented in SQLAlchemy first"
     )


### PR DESCRIPTION
The following PR adds support for the new version of SqlAlchemy 2.0 which has been supported. The PR provides minimal support of feature which were previously supported for SqlAlchemy 1.3 and 1.4 along with a few new functionalities as provided below:

1. Support Views
2. Support getting table info for specific schemas
3. Get view definition
4. Get multi columns
5. Get multi indexes
6. Get multi PK constraint
7. Get multi foreign keys
8. Modify table names in tests to not get view info for emulator
9. Adding test suite for 2.0 support

Along with this, we will now run SqlAlchemy 2.0 as a system test for pre-submits.

