### PR TITLE
build: allow merging pull requests that are not up to date

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,7 +5,7 @@ branchProtectionRules:
 # Defaults to `main`
 - pattern: main
   requiresCodeOwnerReviews: true
-  requiresStrictStatusChecks: true
+  requiresStrictStatusChecks: false
   requiredStatusCheckContexts:
     - 'lint'
     - 'unit'


### PR DESCRIPTION
Allow pull requests that are not up to date with main to be merged, as we otherwise have re-run all tests for each PR before merging, which takes too long.