### PR TITLE
fix: Index on a table containing columns with no sort order fails while reflecting the table

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -1011,7 +1011,9 @@ class SpannerDialect(DefaultDialect):
                     "column_names": row[3],
                     "unique": row[4],
                     "column_sorting": {
-                        col: order for col, order in zip(row[3], row[5])
+                        col: order.lower()
+                        for col, order in zip(row[3], row[5])
+                        if order is not None
                     },
                 }
                 row[0] = row[0] or None


### PR DESCRIPTION
Fixes #399

1. Ignore None order as SQLAlchemy only processes ASC, DESC
2. SQLAlchemy requires order in lowercase (asc, desc)