### PR TITLE
docs: add test for using FOR UPDATE

### DIFF
--- a/test/mockserver_tests/mock_server_test_base.py
+++ b/test/mockserver_tests/mock_server_test_base.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from google.cloud.spanner_dbapi.parsed_statement import AutocommitDmlMode
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.testing.plugin.plugin_base import fixtures
@@ -77,6 +78,52 @@ def add_single_result(
     )
     result.rows.extend(row)
     MockServerTestBase.spanner_service.mock_spanner.add_result(sql, result)
+
+
+def add_singer_query_result(sql: str):
+    result = result_set.ResultSet(
+        dict(
+            metadata=result_set.ResultSetMetadata(
+                dict(
+                    row_type=spanner_type.StructType(
+                        dict(
+                            fields=[
+                                spanner_type.StructType.Field(
+                                    dict(
+                                        name="singers_id",
+                                        type=spanner_type.Type(
+                                            dict(code=spanner_type.TypeCode.INT64)
+                                        ),
+                                    )
+                                ),
+                                spanner_type.StructType.Field(
+                                    dict(
+                                        name="singers_name",
+                                        type=spanner_type.Type(
+                                            dict(code=spanner_type.TypeCode.STRING)
+                                        ),
+                                    )
+                                ),
+                            ]
+                        )
+                    )
+                )
+            ),
+        )
+    )
+    result.rows.extend(
+        [
+            (
+                "1",
+                "Jane Doe",
+            ),
+            (
+                "2",
+                "John Doe",
+            ),
+        ]
+    )
+    add_result(sql, result)
 
 
 class MockServerTestBase(fixtures.TestBase):

--- a/test/mockserver_tests/test_read_only_transaction.py
+++ b/test/mockserver_tests/test_read_only_transaction.py
@@ -22,10 +22,10 @@ from google.cloud.spanner_v1 import (
     BeginTransactionRequest,
     TransactionOptions,
 )
-from test.mockserver_tests.mock_server_test_base import MockServerTestBase
-from test.mockserver_tests.mock_server_test_base import add_result
-import google.cloud.spanner_v1.types.type as spanner_type
-import google.cloud.spanner_v1.types.result_set as result_set
+from test.mockserver_tests.mock_server_test_base import (
+    MockServerTestBase,
+    add_singer_query_result,
+)
 
 
 class TestReadOnlyTransaction(MockServerTestBase):
@@ -71,49 +71,3 @@ class TestReadOnlyTransaction(MockServerTestBase):
                 ),
                 begin_request.options,
             )
-
-
-def add_singer_query_result(sql: str):
-    result = result_set.ResultSet(
-        dict(
-            metadata=result_set.ResultSetMetadata(
-                dict(
-                    row_type=spanner_type.StructType(
-                        dict(
-                            fields=[
-                                spanner_type.StructType.Field(
-                                    dict(
-                                        name="singers_id",
-                                        type=spanner_type.Type(
-                                            dict(code=spanner_type.TypeCode.INT64)
-                                        ),
-                                    )
-                                ),
-                                spanner_type.StructType.Field(
-                                    dict(
-                                        name="singers_name",
-                                        type=spanner_type.Type(
-                                            dict(code=spanner_type.TypeCode.STRING)
-                                        ),
-                                    )
-                                ),
-                            ]
-                        )
-                    )
-                )
-            ),
-        )
-    )
-    result.rows.extend(
-        [
-            (
-                "1",
-                "Jane Doe",
-            ),
-            (
-                "2",
-                "John Doe",
-            ),
-        ]
-    )
-    add_result(sql, result)

--- a/test/mockserver_tests/test_stale_reads.py
+++ b/test/mockserver_tests/test_stale_reads.py
@@ -23,17 +23,17 @@ from google.cloud.spanner_v1 import (
     BeginTransactionRequest,
     TransactionOptions,
 )
-from test.mockserver_tests.mock_server_test_base import MockServerTestBase
-from test.mockserver_tests.mock_server_test_base import add_result
-import google.cloud.spanner_v1.types.type as spanner_type
-import google.cloud.spanner_v1.types.result_set as result_set
+from test.mockserver_tests.mock_server_test_base import (
+    MockServerTestBase,
+    add_singer_query_result,
+)
 
 
 class TestStaleReads(MockServerTestBase):
     def test_stale_read_multi_use(self):
         from test.mockserver_tests.stale_read_model import Singer
 
-        add_singer_query_result("SELECT singers.id, singers.name \n" + "FROM singers")
+        add_singer_query_result("SELECT singers.id, singers.name \nFROM singers")
         engine = create_engine(
             "spanner:///projects/p/instances/i/databases/d",
             echo=True,
@@ -82,7 +82,7 @@ class TestStaleReads(MockServerTestBase):
     def test_stale_read_single_use(self):
         from test.mockserver_tests.stale_read_model import Singer
 
-        add_singer_query_result("SELECT singers.id, singers.name\n" + "FROM singers")
+        add_singer_query_result("SELECT singers.id, singers.name \nFROM singers")
         engine = create_engine(
             "spanner:///projects/p/instances/i/databases/d",
             echo=True,
@@ -121,49 +121,3 @@ class TestStaleReads(MockServerTestBase):
                 ),
                 execute_request.transaction.single_use,
             )
-
-
-def add_singer_query_result(sql: str):
-    result = result_set.ResultSet(
-        dict(
-            metadata=result_set.ResultSetMetadata(
-                dict(
-                    row_type=spanner_type.StructType(
-                        dict(
-                            fields=[
-                                spanner_type.StructType.Field(
-                                    dict(
-                                        name="singers_id",
-                                        type=spanner_type.Type(
-                                            dict(code=spanner_type.TypeCode.INT64)
-                                        ),
-                                    )
-                                ),
-                                spanner_type.StructType.Field(
-                                    dict(
-                                        name="singers_name",
-                                        type=spanner_type.Type(
-                                            dict(code=spanner_type.TypeCode.STRING)
-                                        ),
-                                    )
-                                ),
-                            ]
-                        )
-                    )
-                )
-            ),
-        )
-    )
-    result.rows.extend(
-        [
-            (
-                "1",
-                "Jane Doe",
-            ),
-            (
-                "2",
-                "John Doe",
-            ),
-        ]
-    )
-    add_result(sql, result)


### PR DESCRIPTION
Spanner now supports FOR UPDATE clauses. This change adds a test to verify that FOR UPDATE clauses can be generated with the Spanner SQLAlchemy provider.

See also https://cloud.google.com/spanner/docs/release-notes#January_27_2025

cc @skuruppu 