### PR TITLE
bug: update google-cloud-spanner dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ name = "sqlalchemy-spanner"
 description = "SQLAlchemy dialect integrated into Cloud Spanner database"
 dependencies = [
     "sqlalchemy>=1.1.13",
-    "google-cloud-spanner>=3.12.0",
+    "google-cloud-spanner>=3.54.0",
     "alembic",
 ]
 extras = {


### PR DESCRIPTION
The library now depends on google-cloud-spanner-3.54.0 for transaction isolation level support.

Fixes #659