### PR TITLE
chore: Release candidate v1.13.0rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.13.0](https://github.com/googleapis/python-spanner-sqlalchemy/compare/v1.12.0...v1.13.0) (2025-06-05)
+## [1.13.0rc0](https://github.com/googleapis/python-spanner-sqlalchemy/compare/v1.12.0...v1.13.0rc0) (2025-06-05)
 
 
 ### Features

--- a/google/cloud/sqlalchemy_spanner/version.py
+++ b/google/cloud/sqlalchemy_spanner/version.py
@@ -4,4 +4,4 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-__version__ = "1.13.0"
+__version__ = "1.13.0rc0"


### PR DESCRIPTION
## [1.13.0rc0](https://github.com/googleapis/python-spanner-sqlalchemy/compare/v1.12.0...v1.13.0rc0) (2025-06-05)


### Features

* Introduce compatibility with native namespace packages ([#375](https://github.com/googleapis/python-spanner-sqlalchemy/issues/375)) ([052e699](https://github.com/googleapis/python-spanner-sqlalchemy/commit/052e699f82a795def518f4f0a32039e1c68174a0))
