### PR TITLE
chore: make the fk query joins consistent

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -1481,11 +1481,11 @@ class SpannerDialect(DefaultDialect):
             )
             FROM information_schema.table_constraints AS tc
             JOIN information_schema.constraint_column_usage AS ccu
-                ON ccu.table_catalog = tc.table_catalog
+                ON ccu.constraint_catalog = tc.table_catalog
                 and ccu.constraint_schema = tc.table_schema
                 and ccu.constraint_name = tc.constraint_name
             JOIN information_schema.constraint_table_usage AS ctu
-                ON ctu.table_catalog = tc.table_catalog
+                ON ctu.constraint_catalog = tc.table_catalog
                 and ctu.constraint_schema = tc.table_schema
                 and ctu.constraint_name = tc.constraint_name
             JOIN information_schema.key_column_usage AS kcu


### PR DESCRIPTION
Fixes a tiny issue in the FK metadata query, where the JOIN condition used the `table_catalog` instead of `constraint_catalog`. This difference does not really have an actual impact, as the catalog is always the same, but this makes the code look more consistent.