### PR TITLE
fix: don't rollback non-spanner connections on reset

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -71,8 +71,6 @@ def reset_connection(dbapi_conn, connection_record, reset_state=None):
 
         dbapi_conn.staleness = None
         dbapi_conn.read_only = False
-    else:
-        dbapi_conn.rollback()
 
 
 # register a method to get a single value of a JSON object


### PR DESCRIPTION
This is the simplest way to address bug #706 and address the `AttributeError: 'Connection' object has no attribute 'rollback'` I'm seeing when connections from BigQuery engines get caught by this event handler.

I think we should be able to rely on SQLAlchemy's [reset on return](https://docs.sqlalchemy.org/en/20/core/pooling.html#reset-on-return) behaviour to rollback transactions when they're reset rather than call rollback ourselves. That behaviour is also something end users can configure, so it'd be good to respect their settings if they disable the behaviour.

Fixes: #706