### PR TITLE
feat: support informational foreign keys

### DIFF
--- a/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -652,6 +652,12 @@ class SpannerDDLCompiler(DDLCompiler):
             "Create UNIQUE indexes instead."
         )
 
+    def visit_foreign_key_constraint(self, constraint, **kw):
+        text = super().visit_foreign_key_constraint(constraint, **kw)
+        if constraint.dialect_options.get("spanner", {}).get("not_enforced", False):
+            text += " NOT ENFORCED"
+        return text
+
     def post_create_table(self, table):
         """Build statements to be executed after CREATE TABLE.
 

--- a/samples/informational_fk.py
+++ b/samples/informational_fk.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from sqlalchemy import String, ForeignKey
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Singer(Base):
+    __tablename__ = "singers"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    first_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+
+
+class Album(Base):
+    __tablename__ = "albums"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    # Create an informational foreign key with the not_enforced argument.
+    # See Spanner documentation for more details:
+    # https://cloud.google.com/spanner/docs/foreign-keys/overview#create-table-with-informational-fk
+    singer_id: Mapped[str] = mapped_column(ForeignKey("singers.id", spanner_not_enforced=True))

--- a/test/mockserver_tests/not_enforced_fk_model.py
+++ b/test/mockserver_tests/not_enforced_fk_model.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Singer(Base):
+    __tablename__ = "singers"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    name: Mapped[str]
+
+
+class Album(Base):
+    __tablename__ = "albums"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    singer_id: Mapped[str] = mapped_column(
+        ForeignKey("singers.id", spanner_not_enforced=True)
+    )

--- a/test/mockserver_tests/test_not_enforced_fk.py
+++ b/test/mockserver_tests/test_not_enforced_fk.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import create_engine
+from sqlalchemy.testing import eq_, is_instance_of
+from google.cloud.spanner_v1 import (
+    FixedSizePool,
+    ResultSet,
+)
+from test.mockserver_tests.mock_server_test_base import (
+    MockServerTestBase,
+    add_result,
+)
+from google.cloud.spanner_admin_database_v1 import UpdateDatabaseDdlRequest
+
+
+class TestNotEnforcedFK(MockServerTestBase):
+    """Ensure we emit correct DDL for not enforced foreign keys."""
+
+    def test_create_table(self):
+        from test.mockserver_tests.not_enforced_fk_model import Base
+
+        add_result(
+            """SELECT true
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA="" AND TABLE_NAME="singers"
+LIMIT 1
+""",
+            ResultSet(),
+        )
+        add_result(
+            """SELECT true
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA="" AND TABLE_NAME="albums"
+LIMIT 1
+""",
+            ResultSet(),
+        )
+        engine = create_engine(
+            "spanner:///projects/p/instances/i/databases/d",
+            connect_args={"client": self.client, "pool": FixedSizePool(size=10)},
+        )
+        Base.metadata.create_all(engine)
+        requests = self.database_admin_service.requests
+        eq_(1, len(requests))
+        is_instance_of(requests[0], UpdateDatabaseDdlRequest)
+        eq_(2, len(requests[0].statements))
+        eq_(
+            "CREATE TABLE singers (\n"
+            "\tid STRING(MAX) NOT NULL, \n"
+            "\tname STRING(MAX) NOT NULL\n"
+            ") PRIMARY KEY (id)",
+            requests[0].statements[0],
+        )
+        eq_(
+            "CREATE TABLE albums (\n"
+            "\tid STRING(MAX) NOT NULL, \n"
+            "\tname STRING(MAX) NOT NULL, \n"
+            "\tsinger_id STRING(MAX) NOT NULL, \n"
+            "\tFOREIGN KEY(singer_id) REFERENCES singers (id) NOT ENFORCED\n"
+            ") PRIMARY KEY (id)",
+            requests[0].statements[1],
+        )


### PR DESCRIPTION
Add support for informational foreign keys with the 'not enforced' keyword: https://cloud.google.com/spanner/docs/foreign-keys/overview#create-table-with-informational-fk

Fixes #718