### PR TITLE
fix: pin working google-cloud-spanner version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ name = "sqlalchemy-spanner"
 description = "SQLAlchemy dialect integrated into Cloud Spanner database"
 dependencies = [
     "sqlalchemy>=1.1.13",
-    "google-cloud-spanner>=3.55.0",
+    "google-cloud-spanner==3.55.0",
     "alembic",
 ]
 extras = {


### PR DESCRIPTION
mockserver tests are failing with google-cloud-spanner==3.56.0 The request sequence these tests rely on has gone from

`[BatchCreateSessionsRequest, BeginTransactionRequest, ExecuteSqlRequest, CommitRequest]`

to

`[BatchCreateSessionsRequest, CreateSessionRequest, BeginTransactionRequest, ExecuteSqlRequest, CommitRequest]`

It's not clear to me if this is an actual bug or just an issue with the tests.

issue: #728