### PR TITLE
chore: exclude last_update from the THEN RETURN clause

### DIFF
--- a/samples/model.py
+++ b/samples/model.py
@@ -199,12 +199,16 @@ class TicketSale(Base):
         String(36), ForeignKey("singers.id", spanner_not_enforced=True)
     )
     # Create a commit timestamp column and set a client-side default of
-    # PENDING_COMMIT_TIMESTAMP() An event handler below is responsible for
+    # PENDING_COMMIT_TIMESTAMP(). An event handler below is responsible for
     # setting PENDING_COMMIT_TIMESTAMP() on updates. If using SQLAlchemy
     # core rather than the ORM, callers will need to supply their own
     # PENDING_COMMIT_TIMESTAMP() values in their inserts & updates.
+    #
+    # Columns that use PENDING_COMMIT_TIMESTAMP() cannot be included in a
+    # THEN RETURN clause.
     last_update_time: Mapped[datetime.datetime] = mapped_column(
         spanner_allow_commit_timestamp=True,
+        spanner_exclude_from_returning=True,
         default=text("PENDING_COMMIT_TIMESTAMP()"),
     )
 


### PR DESCRIPTION
Columns that are assigned a `PENDING_COMMIT_TIMESTAMP()` value cannot be
included in `THEN RETURN` clauses.

Fixes this build error: https://github.com/googleapis/python-spanner-sqlalchemy/actions/runs/19180600096/job/54948361746?pr=798

A recent fix in the Emulator caused the samples for SQLAlchemy to start fail. That is not due to a bug in the Emulator, but due to a bug __fix__ in the Emulator. Previously, the Emulator would allow something that would fail on Spanner. That difference has now been fixed.