### PR TITLE
chore: librarian release pull request: 20251215T133347Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: sqlalchemy-spanner
-    version: 1.17.1
+    version: 1.17.2
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/sqlalchemy-spanner/#history
 
+## [1.17.2](https://github.com/googleapis/google-cloud-python/compare/sqlalchemy-spanner-v1.17.1...sqlalchemy-spanner-v1.17.2) (2025-12-15)
+
+
+### Bug Fixes
+
+* Retrieve columns in compound indexes in correct order (#798) ([9afe49bb720356c58890931c17546650ffd61f88](https://github.com/googleapis/google-cloud-python/commit/9afe49bb720356c58890931c17546650ffd61f88))
+
 ## [1.17.1](https://github.com/googleapis/python-spanner-sqlalchemy/compare/v1.17.0...v1.17.1) (2025-10-21)
 
 

--- a/google/cloud/sqlalchemy_spanner/version.py
+++ b/google/cloud/sqlalchemy_spanner/version.py
@@ -4,4 +4,4 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-__version__ = "1.17.1"
+__version__ = "1.17.2"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>sqlalchemy-spanner: 1.17.2</summary>

## [1.17.2](https://github.com/googleapis/python-spanner-sqlalchemy/compare/v1.17.1...v1.17.2) (2025-12-15)

### Bug Fixes

* Retrieve columns in compound indexes in correct order (#798) ([9afe49bb](https://github.com/googleapis/python-spanner-sqlalchemy/commit/9afe49bb))

</details>